### PR TITLE
assigning occ_category as Residential based on hotel/otherb units

### DIFF
--- a/developments_build/sql/_occ.sql
+++ b/developments_build/sql/_occ.sql
@@ -10,22 +10,18 @@ INPUTS:
     INIT_devdb (
         job_number text, 
         job_type text,
-        job_description text,
-        status_a text,
         _occ_init text,
         _occ_prop text,
-        _units_prop numeric, 
-        address text
     )
-    housing_input_lookup_occupancy (
-        doboccupancycode2008 text,
-        doboccupancycode1968 text,
-        dcpclassificationnew text
-    )
+    
+	occ_lookup (
+		* dob_occ text,
+		occ text
+	)
 
 OUTPUTS:
     OCC_devdb (
-        job_number text, 
+        * job_number text, 
         occ_init text,
         occ_prop text,
         occ_category text

--- a/developments_build/sql/devdb_create_mid.sql
+++ b/developments_build/sql/devdb_create_mid.sql
@@ -122,11 +122,16 @@ JOIN_occ as (
         a.*,
         b.occ_init,
         b.occ_prop,
-        b.occ_category
+        (CASE WHEN hotel_init IS NOT NULL
+            OR hotel_prop IS NOT NULL
+            OR otherb_init IS NOT NULL
+            OR otherb_prop IS NOT NULL
+            THEN 'Residential'
+        ELSE b.occ_category END) as occ_category
     FROM JOIN_units a
     LEFT JOIN OCC_devdb b
     ON a.job_number = b.job_number
-) 
+)
 SELECT *
 INTO MID_devdb
 FROM JOIN_occ;


### PR DESCRIPTION
issue #27
If there is a value in the classA, classB, and hotel units field make the occupancy code residential; Simplify residential categories.