### PR TITLE
Only populate complete dates for records with complete status

### DIFF
--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -122,7 +122,7 @@ DRAFT_STATUS_devdb as (
         (CASE
             WHEN status = '5. Complete' 
                 THEN units_net
-            WHEN status = '4. Partial complete' 
+            WHEN status = '4. Partial Complete' 
                 THEN co_latest_units
             ELSE NULL
         END) as units_complete,
@@ -131,7 +131,7 @@ DRAFT_STATUS_devdb as (
         (CASE
             WHEN status = '5. Complete'  
                 THEN NULL
-            WHEN status = '4. Partial complete'
+            WHEN status = '4. Partial Complete'
                 THEN units_net-co_latest_units
             ELSE units_net
         END) units_incomplete

--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -11,6 +11,7 @@ INPUTS:
         status_q date,
         _status text,
         year_complete text,
+        quarter_complete text,
         co_latest_units numeric,
         co_latest_certtype text,
         units_complete numeric,
@@ -33,6 +34,7 @@ OUTPUTS:
         status_date date,
         status_q date,
         year_complete text,
+        quarter_complete text,
         units_complete numeric,
         units_incomplete numeric,
         units_net numeric,
@@ -56,6 +58,7 @@ STATUS_translate as (
         a.job_type,
         a.status_q,
         a.year_complete,
+        a.quarter_complete,
         a.units_net,
         a.co_latest_units,
         a.status_date,
@@ -99,28 +102,36 @@ DRAFT_STATUS_devdb as (
         units_net,
         address,
         occ_prop,
-        -- update year_compelte based on job_type and status
+        -- update year_compelete based on job_type and status
         (CASE
             WHEN job_type = 'Demolition'
-                OR status = 'Withdrawn'
+                OR status NOT IN ('4. Partial Complete', '5. Complete')
                 THEN NULL
             ELSE year_complete
         END) as year_complete,
 
+        -- update quarter_compelete based on job_type and status
+        (CASE
+            WHEN job_type = 'Demolition'
+                OR status NOT IN ('4. Partial Complete', '5. Complete')
+                THEN NULL
+            ELSE quarter_complete
+        END) as quarter_complete,
+
         -- Assign units_complete based on status
         (CASE
-            WHEN status LIKE 'Complete%' 
+            WHEN status = '5. Complete' 
                 THEN units_net
-            WHEN status = 'Partial complete' 
+            WHEN status = '4. Partial complete' 
                 THEN co_latest_units
             ELSE NULL
         END) as units_complete,
 
         -- Assing units_incomplete
         (CASE
-            WHEN status LIKE 'Complete%' 
+            WHEN status = '5. Complete'  
                 THEN NULL
-            WHEN status = 'Partial complete'
+            WHEN status = '4. Partial complete'
                 THEN units_net-co_latest_units
             ELSE units_net
         END) units_incomplete

--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -105,7 +105,7 @@ DRAFT_STATUS_devdb as (
         -- update year_compelete based on job_type and status
         (CASE
             WHEN job_type = 'Demolition'
-                OR status = '9. Withdrawn'
+                OR status NOT IN ('4. Partial Complete', '5. Complete')
                 THEN NULL
             ELSE year_complete
         END) as year_complete,


### PR DESCRIPTION
#29 
The only records that should have complete quarter and years are those that have statuses of Complete or Partial Complete.