### PR TITLE
QAQC occupancy checks

### DIFF
--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -18,7 +18,7 @@ DROP TABLE IF EXISTS MID_qaqc;
 WITH
 JOBNUMBER_null_init AS(
     SELECT job_number
-    FROM UNITS_devdb
+    FROM MID_devdb
     WHERE
     job_type IN ('Demolition' , 'Alteration') 
     AND resid_flag = 'Residential' 
@@ -26,7 +26,7 @@ JOBNUMBER_null_init AS(
 
 JOBNUMBER_null_prop AS(
     SELECT job_number
-    FROM UNITS_devdb
+    FROM MID_devdb
     WHERE
     job_type IN ('New Building' , 'Alteration' 
     AND resid_flag = 'Residential' 
@@ -121,4 +121,4 @@ SELECT a.*,
 	END) as b_likely_occ_desc
     
 INTO MID_qaqc
-FROM STATUS_qaqc a;
+FROM UNITS_qaqc a;

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -1,11 +1,17 @@
 /** QAQC
-    units_init_null
-	units_init_null
-    dup_equal_units
-    dup_diff_units
-    b_nonres_with_units
-	units_res_accessory
-	b_likely_occ_desc
+    UNITS:
+        units_init_null
+	    units_init_null
+        dup_equal_units
+        dup_diff_units
+    OCC:
+        b_nonres_with_units
+	    units_res_accessory
+	    b_likely_occ_desc
+    CO:
+        units_co_prop_mismatch TODO
+    STATUS:
+        z_incomp_tract_home TODO
 **/
 
 DROP TABLE IF EXISTS MID_qaqc;

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -1,0 +1,92 @@
+/** QAQC
+    dup_equal_units
+    dup_diff_units
+    b_nonres_with_units
+	units_res_accessory
+	b_likely_occ_desc
+**/
+
+DROP TABLE IF EXISTS MID_qaqc;
+WITH
+JOBNUMBER_dup_equal_units AS (
+    SELECT a.job_number
+    FROM MID_devdb a 
+    JOIN MID_devdb b 
+    ON a.job_type = b.job_type
+    AND a.bbl = b.bbl
+    AND a.address = b.address
+    AND a.classa_net = b.classa_net
+    AND a.job_number <> b.job_number
+),
+
+JOBNUMBER_dup_diff_units AS (
+    SELECT a.job_number
+    FROM MID_devdb a 
+    JOIN MID_devdb b 
+    ON a.job_type = b.job_type
+    AND a.bbl = b.bbl
+    AND a.address = b.address
+    AND a.classa_net <> b.classa_net
+    AND a.job_number <> b.job_number
+),
+
+JOBNUMBER_nonres_units AS (
+	SELECT job_number 
+	FROM MID_devdb
+	WHERE resid_flag IS NULL
+	AND (classa_prop <> 0 OR classa_init <> 0)
+),
+
+JOBNUMBER_accessory AS (
+	SELECT job_number
+	FROM MID_devdb
+	WHERE ((address LIKE '%GAR%' 
+					OR job_desc ~* 'pool|shed|gazebo|garage')
+			AND (classa_init::numeric IN (1,2) 
+					OR classa_prop::numeric IN (1,2)))
+	OR ((occ_initial LIKE '%(U)%'
+			OR occ_initial LIKE '%(K)%'
+			OR occ_proposed LIKE '%(U)%'
+			OR occ_proposed LIKE '%(K)%')
+		AND (classa_init::numeric > 0 
+			OR classa_prop::numeric > 0))
+),
+
+JOBNUMBER_b_likely AS (
+    SELECT job_number
+    FROM MID_devdb
+    WHERE (job_type = 'Alteration' 
+            AND (occ_initial LIKE '%Residential%' AND occ_proposed LIKE '%Hotel%') 
+            OR (occ_initial LIKE '%Hotel%' AND occ_proposed LIKE '%Residential%'))
+    OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hoste|Lodge|UG 5', '|',
+                          'Group 5|Grp 5|Class B|SRO|Single room', '|',
+                          'Furnished|Rooming unit|Dorm|Transient', '|',
+                          'Homeless|Shelter|Group quarter|Beds', '|',
+                          'Convent|Monastery|Accommodation|Harassment', '|',
+                          'CNH|Settlement|Halfway|Nursing home|Assisted|')
+)
+
+SELECT a.*,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_dup_equal_units) THEN 1
+	 	ELSE 0
+	END) as dup_equal_units,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_dup_diff_units) THEN 1
+	 	ELSE 0
+	END) as dup_diff_units,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_nonres_units) THEN 1
+	 	ELSE 0
+	END) as b_nonres_with_units,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_accessory) THEN 1
+	 	ELSE 0
+	END) as units_res_accessory,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_b_likely) THEN 1
+	 	ELSE 0
+	END) as b_likely_occ_desc
+    
+INTO MID_qaqc
+FROM STATUS_qaqc a;

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -1,4 +1,6 @@
 /** QAQC
+    units_init_null
+	units_init_null
     dup_equal_units
     dup_diff_units
     b_nonres_with_units
@@ -8,6 +10,22 @@
 
 DROP TABLE IF EXISTS MID_qaqc;
 WITH
+JOBNUMBER_null_init AS(
+    SELECT job_number
+    FROM UNITS_devdb
+    WHERE
+    job_type IN ('Demolition' , 'Alteration') 
+    AND resid_flag = 'Residential' 
+    AND units_init IS NULL),
+
+JOBNUMBER_null_prop AS(
+    SELECT job_number
+    FROM UNITS_devdb
+    WHERE
+    job_type IN ('New Building' , 'Alteration' 
+    AND resid_flag = 'Residential' 
+    AND units_prop IS NULL),   
+
 JOBNUMBER_dup_equal_units AS (
     SELECT a.job_number
     FROM MID_devdb a 
@@ -67,6 +85,14 @@ JOBNUMBER_b_likely AS (
 )
 
 SELECT a.*,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_null_init) THEN 1
+	 	ELSE 0
+	END) as units_init_null,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_null_prop) THEN 1
+	 	ELSE 0
+	END) as units_init_null,
     (CASE 
 	 	WHEN a.job_number IN (SELECT job_number FROM JOBNUMBER_dup_equal_units) THEN 1
 	 	ELSE 0

--- a/developments_build/sql/qaqc/qaqc_occ.sql
+++ b/developments_build/sql/qaqc/qaqc_occ.sql
@@ -1,0 +1,18 @@
+/** QAQC
+	b_nonres_with_units
+	units_res_accessory
+	b_likely_occ_desc
+**/
+
+DROP TABLE IF EXISTS OCC_qaqc;
+WITH 
+JOBNUMBER_nonres_units AS (
+
+),
+JOBNUMBER_accessory AS (
+
+),
+JOBNUMBER_b_likely AS (
+
+)
+

--- a/developments_build/sql/qaqc/qaqc_occ.sql
+++ b/developments_build/sql/qaqc/qaqc_occ.sql
@@ -3,16 +3,3 @@
 	units_res_accessory
 	b_likely_occ_desc
 **/
-
-DROP TABLE IF EXISTS OCC_qaqc;
-WITH 
-JOBNUMBER_nonres_units AS (
-
-),
-JOBNUMBER_accessory AS (
-
-),
-JOBNUMBER_b_likely AS (
-
-)
-

--- a/developments_build/sql/qaqc/qaqc_occ.sql
+++ b/developments_build/sql/qaqc/qaqc_occ.sql
@@ -1,5 +1,0 @@
-/** QAQC
-	b_nonres_with_units
-	units_res_accessory
-	b_likely_occ_desc
-**/


### PR DESCRIPTION
These checks depend on MID_devdb combination of variables.

UNITS checks:
+ units_init_null
+ units_init_null
+ dup_equal_units
+ dup_diff_units

OCC checks:
+ b_nonres_with_units
+ units_res_accessory
+ b_likely_occ_desc