### PR TITLE
Making sure a demolition with a non null date_Statux will get status complete

### DIFF
--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -75,9 +75,8 @@ STATUS_translate as (
                 )
                 THEN '4. Partial Complete'
 
-            WHEN a.job_type = 'Demolition' 
-                AND status_translate(a._job_status)
-                    IN ('5. Complete','3. Permited') 
+            WHEN a.job_type = 'Demolition'
+                AND date_statusx IS NOT NULL
                 THEN '5. Complete'
 
             WHEN a.x_withdrawal IN ('W', 'C')


### PR DESCRIPTION
HED confirmed that 
> Make status Complete for demolition if it has a value in Date_StatusX (status_x)
will overwrite previous logic
(#40)