### PR TITLE
Revise b_likely_occ_desc

### DIFF
--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -125,9 +125,8 @@ JOBNUMBER_accessory AS (
 JOBNUMBER_b_likely AS (
     SELECT job_number
     FROM MID_devdb
-    WHERE (job_type = 'Alteration' 
-            AND (occ_initial LIKE '%Residential%' AND occ_proposed LIKE '%Hotel%') 
-            OR (occ_initial LIKE '%Hotel%' AND occ_proposed LIKE '%Residential%'))
+    WHERE occ_initial ~* 'hotel|assisted|incapacitated|restrained'
+	OR occ_proposed ~* 'hotel|assisted|incapacitated|restrained'
     OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hoste|Lodge|UG 5', '|',
                           'Group 5|Grp 5|Class B|SRO|Single room', '|',
                           'Furnished|Rooming unit|Dorm|Transient', '|',


### PR DESCRIPTION
Responding to:

>add this -> occ_init or occ_prop contains "hotel", "assisted", "incapacitated", "restrained", "dormitories"
>remove this -> job_type = Alteration and occ_initial contains “residential” and occ_proposed contains “hotel” OR
>remove this -> job_type = Alteration and occ_initial contains “hotel” and occ_proposed contains “residential”
>keep ->job_desc contains any of the following words ~* 'Hotel|Motel|Boarding|Hoste|Lodge|UG 5|Group 5|Grp 5|Class B|SRO|Single room|Furnished|Rooming unit|Dorm|Transient|Homeless|Shelter|Group quarter|Beds|Convent|Monastery|Accommodation|Harassment|CNH|Settlement|Halfway|Nursing home|Assisted|'