### PR TITLE
Set NULL stories_prop for DM and stories_init for NB

### DIFF
--- a/developments_build/sql/_init.sql
+++ b/developments_build/sql/_init.sql
@@ -112,13 +112,18 @@ JOBNUMBER_relevant as (
     -- and proposedoccupancy (3 records affected)
 	replace(existingoccupancy, '.', '') as _occ_initial, 
     replace(proposedoccupancy, '.', '') as _occ_proposed,
+	
     -- set 0 -> null for jobtype = A1 or DM
 	(CASE WHEN jobtype ~* 'A1|DM' 
         THEN nullif(existingnumstories, '0')::numeric
-		ELSE existingnumstories::numeric
+		ELSE NULL
     END) as stories_init,
 
-	proposednumstories::numeric as stories_prop,
+	-- set 0 -> null for jobtype = A1 or NB
+	(CASE WHEN jobtype ~* 'A1|NB' 
+        THEN nullif(proposednumstories, '0')::numeric
+		ELSE NULL
+    END) as stories_prop,
 
     -- set 0 -> null for jobtype = A1 or DM\
 	(CASE WHEN jobtype ~* 'A1|DM' 


### PR DESCRIPTION
From #100 
> Stories_prop should be null for demolitions and stories_init should be null for new buildings.

This PR keeps old logic where 0 values for `stories_init` and `stories_prop` get set to NULL.