### PR TITLE
Update inactive logic

### DIFF
--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -78,6 +78,8 @@ DRAFT_STATUS_devdb as (
         END as job_status,
         a.date_permittd,
         a.date_lastupdt::date,
+        a.classa_init,
+        a.classa_prop,
         a.classa_net,
         a.address,
         a.co_latest_units,
@@ -141,7 +143,7 @@ FROM DRAFT_STATUS_devdb;
 
 -- Jobs matching with a newer, (partially) complete job get set to inactive
 WITH completejobs AS (
-	SELECT address, job_type, date_lastupdt, job_status
+	SELECT address, job_type, date_lastupdt, job_status, classa_init, classa_prop
 	FROM STATUS_devdb
 	WHERE classa_init IS NOT NULL
     AND classa_prop IS NOT NULL

--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -100,7 +100,7 @@ SELECT
     complete_year,
     complete_qrtr,
     co_latest_units as classa_complt,
-    classa_net-coalesce(co_latest_units,0) as classa_incmpl
+    classa_net-coalesce(co_latest_units,0) as classa_incmpl,
     classa_net,
     address,
     occ_proposed,

--- a/developments_build/sql/_status.sql
+++ b/developments_build/sql/_status.sql
@@ -116,6 +116,8 @@ SELECT
         ELSE classa_net
     END) as classa_incmpl,
 
+    classa_init,
+    classa_prop,
     classa_net,
     address,
     occ_proposed,
@@ -141,8 +143,8 @@ FROM DRAFT_STATUS_devdb;
 WITH completejobs AS (
 	SELECT address, job_type, date_lastupdt, job_status
 	FROM STATUS_devdb
-	WHERE classa_init::numeric > 0
-    AND classa_prop::numeric > 0
+	WHERE classa_init IS NOT NULL
+    AND classa_prop IS NOT NULL
 	AND job_status IN ('4. Partially Completed Construction', '5. Completed Construction'))
 UPDATE STATUS_devdb a 
 SET job_inactive = 'Inactive'


### PR DESCRIPTION
+ Filed Application OR, Approved Application OR, Permitted for Construction without update in past 3 years
+ A filed, approved application, or permitted job matches with a (partially) completed job that has ~positive~ non-NULL classa_init and classa_prop on:
     + address
     + job_type
     + classa_init
     + classa_prop
     + date_lastupdt of the incomplete job is before the date_lastupdt of the complete job