### PR TITLE
Change b-nonres with units

### DIFF
--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -85,8 +85,8 @@ JOBNUMBER_null_prop AS(
 JOBNUMBER_nonres_units AS (
 	SELECT job_number 
 	FROM MID_devdb
-	WHERE resid_flag IS NULL
-	AND (classa_prop <> 0 OR classa_init <> 0)
+	WHERE (occ_initial !~* 'residential' AND classa_init <> 0)
+	OR (occ_proposed !~* 'residential' AND classa_prop <> 0)
 ),
 JOBNUMBER_accessory AS (
 	SELECT job_number

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -85,8 +85,8 @@ JOBNUMBER_null_prop AS(
 JOBNUMBER_nonres_units AS (
 	SELECT job_number 
 	FROM MID_devdb
-	WHERE (occ_initial !~* 'residential' AND classa_init <> 0)
-	OR (occ_proposed !~* 'residential' AND classa_prop <> 0)
+	WHERE (occ_initial !~* 'residential' AND classa_init <> 0 AND classa_init IS NOT NULL)
+	OR (occ_proposed !~* 'residential' AND classa_prop <> 0 AND classa_prop IS NOT NULL)
 ),
 JOBNUMBER_accessory AS (
 	SELECT job_number


### PR DESCRIPTION
#203 
Logic is:
```sql
(occ_initial !~* 'residential' AND classa_init <> 0)
OR (occ_proposed !~* 'residential' AND classa_prop <> 0)
```
Need to verify this. This results in 34% of records getting this flag.