### PR TITLE
Backfill boro

### DIFF
--- a/developments_build/sql/_geo.sql
+++ b/developments_build/sql/_geo.sql
@@ -80,7 +80,7 @@ DRAFT as (
             trim(b.geo_address_street)
         )as geo_address,
         b.geo_zipcode,
-        b.geo_boro, 
+        COALESCE(b.geo_boro, a.boro) as geo_boro, 
         b.geo_cd,
         b.geo_council,
         b.geo_ntacode2010, 

--- a/developments_build/sql/_geo.sql
+++ b/developments_build/sql/_geo.sql
@@ -80,7 +80,7 @@ DRAFT as (
             trim(b.geo_address_street)
         )as geo_address,
         b.geo_zipcode,
-        COALESCE(REPLACE(b.geo_boro,'0',NULL), a.boro) as geo_boro, 
+        COALESCE(REPLACE(b.geo_boro,'0', LEFT(b.geo_bin, 1)), a.boro) as geo_boro, 
         b.geo_cd,
         b.geo_council,
         b.geo_ntacode2010, 

--- a/developments_build/sql/_geo.sql
+++ b/developments_build/sql/_geo.sql
@@ -80,7 +80,7 @@ DRAFT as (
             trim(b.geo_address_street)
         )as geo_address,
         b.geo_zipcode,
-        COALESCE(b.geo_boro, a.boro) as geo_boro, 
+        COALESCE(REPLACE(b.geo_boro,'0',NULL), a.boro) as geo_boro, 
         b.geo_cd,
         b.geo_council,
         b.geo_ntacode2010, 

--- a/developments_build/sql/_spatial.sql
+++ b/developments_build/sql/_spatial.sql
@@ -132,6 +132,4 @@ SELECT
 INTO SPATIAL_devdb
 FROM DRAFT_spatial a
 LEFT JOIN lookup_geo b
-ON COALESCE(a.geo_boro, (select boro from _INIT_devdb where uid = a.uid))||
-    a.geo_censustract2010||
-    a.geo_censusblock2010 = b.bctcb2010;
+ON a.geo_boro||a.geo_censustract2010||a.geo_censusblock2010 = b.bctcb2010;


### PR DESCRIPTION
Boro filled in the following hierarchy:
+ Take 1, 2, 3, 4, 5,  from geosupport
+ If geosupport gives 0 (condo or million bin), take first digit of BIN -- note that million BINs get set to NULL in a subsequent step
+ If geosupport gives NULL, take source boro

This is done upstream to use in merge with lookup_geo, as well as in final output.