### PR TITLE
Create _INIT_qaqc using distinct job_numbers

### DIFF
--- a/developments_build/sql/qaqc/qaqc_init.sql
+++ b/developments_build/sql/qaqc/qaqc_init.sql
@@ -13,7 +13,7 @@ DROP TABLE IF EXISTS _INIT_qaqc;
 WITH
 -- identify invalid dates in input data
 JOBNUMBER_invalid_dates AS (
-	SELECT job_number,
+	SELECT DISTINCT job_number,
 		 (CASE WHEN is_date(date_lastupdt) 
 		 		OR date_lastupdt IS NULL THEN 0
 		 	ELSE 1 END) as invalid_date_lastupdt,


### PR DESCRIPTION
Job numbers from _INIT_qaqc flow through to the final QAQC table, so duplicates in an early stage created duplicates later.