### PR TITLE
Fix empty condition for b_likely_occ_desc

### DIFF
--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -108,11 +108,12 @@ JOBNUMBER_b_likely AS (
     WHERE occ_initial ~* 'hotel|assisted|incapacitated|restrained'
 	OR occ_proposed ~* 'hotel|assisted|incapacitated|restrained'
     OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hostel|Lodge|UG 5', '|',
-                          'Group 5|Grp 5|Class B|SRO|Single room', '|',
-                          'Furnished|Rooming unit|Dorm|Transient', '|',
-                          'Homeless|Shelter|Group quarter|Beds', '|',
-                          'Convent|Monastery|Accommodation|Harassment', '|',
-                          'CNH|Settlement|Halfway|Nursing home|Assisted')
+                          'Group 5|Grp 5|Class B|Class ''b''|Class "b"', '|',
+                          'SRO|Single room|Furnished|Rooming unit', '|',
+						  'Dorm |Dorms |Dormitor|Transient|Homeless', '|',
+                          'Shelter|Group quarter|Beds|Convent|Monastery', '|',
+                          'Accommodation|Harassment|CNH|Settlement|Halfway', '|',
+                          'Nursing home|Assisted')
 ),
 JOBNUMBER_co_prop_mismatch AS (
     SELECT job_number, co_latest_certtype

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -107,12 +107,12 @@ JOBNUMBER_b_likely AS (
     FROM MID_devdb
     WHERE occ_initial ~* 'hotel|assisted|incapacitated|restrained'
 	OR occ_proposed ~* 'hotel|assisted|incapacitated|restrained'
-    OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hoste|Lodge|UG 5', '|',
+    OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hostel|Lodge|UG 5', '|',
                           'Group 5|Grp 5|Class B|SRO|Single room', '|',
                           'Furnished|Rooming unit|Dorm|Transient', '|',
                           'Homeless|Shelter|Group quarter|Beds', '|',
                           'Convent|Monastery|Accommodation|Harassment', '|',
-                          'CNH|Settlement|Halfway|Nursing home|Assisted|')
+                          'CNH|Settlement|Halfway|Nursing home|Assisted')
 ),
 JOBNUMBER_co_prop_mismatch AS (
     SELECT job_number, co_latest_certtype

--- a/developments_build/sql/qaqc/qaqc_mid.sql
+++ b/developments_build/sql/qaqc/qaqc_mid.sql
@@ -109,7 +109,7 @@ JOBNUMBER_b_likely AS (
 	OR occ_proposed ~* 'hotel|assisted|incapacitated|restrained'
     OR job_desc ~* CONCAT('Hotel|Motel|Boarding|Hostel|Lodge|UG 5', '|',
                           'Group 5|Grp 5|Class B|Class ''b''|Class "b"', '|',
-                          'SRO|Single room|Furnished|Rooming unit', '|',
+                          'SRO |Single room|Furnished|Rooming unit', '|',
 						  'Dorm |Dorms |Dormitor|Transient|Homeless', '|',
                           'Shelter|Group quarter|Beds|Convent|Monastery', '|',
                           'Accommodation|Harassment|CNH|Settlement|Halfway', '|',


### PR DESCRIPTION
Fix bug caused by trailing |
Add conditions requested today
Add spaces for acronyms that appear in words (e.g. SRO is in the word classrooms)