### PR TITLE
fix school subdistrict geoemtry

### DIFF
--- a/developments_build/01_dataloading.sh
+++ b/developments_build/01_dataloading.sh
@@ -79,6 +79,9 @@ psql $BUILD_ENGINE -c "
         commntydst text,
         councildst text
     );
+
+    UPDATE doe_school_subdistricts
+    SET wkb_geometry = st_multi(ST_CollectionExtract(wkb_geometry,3));
 "
 
 imports_csv lookup_occ &
@@ -87,7 +90,6 @@ imports_csv housing_input_research &
 imports_csv census_units10 &
 imports_csv census_units10adj &
 imports_csv lookup_geo
-
 
 wait 
 display "data loading is complete"


### PR DESCRIPTION
1. previously mixed geometry types (polygon, multipolygon, geometry collection) are now all multipolygon
2. this fix is for HED weekly run, will not have impact on data outcome for EDM (EDM is using a more update to date postgis version, st_intersects with geometry collection is allowed, but not in HED's database)