### PR TITLE
Fix none-numeric classa_init

### DIFF
--- a/developments_build/sql/_init.sql
+++ b/developments_build/sql/_init.sql
@@ -134,9 +134,11 @@ JOBNUMBER_relevant as (
 		ELSE proposedzoningsqft::numeric 
     END) as zoningsft_prop,
 
-	(CASE WHEN jobtype ~* 'NB' THEN 0 
-		ELSE existingdwellingunits::numeric
-	END) as classa_init,
+    -- if existingdwellingunits is not a number then null
+        (CASE WHEN jobtype ~* 'NB' THEN 0 
+        ELSE (CASE WHEN existingdwellingunits ~ '[^0-9]' THEN NULL
+            ELSE existingdwellingunits::numeric END)
+    END) as classa_init,
 
     -- if proposeddwellingunits is not a number then null
 	(CASE WHEN jobtype ~* 'DM' THEN 0


### PR DESCRIPTION
`psql:sql/_init.sql:230: ERROR:  invalid input syntax for type numeric: "....1"`
