### PR TITLE
Remove geo_bbl constraint for deduplication

### DIFF
--- a/developments_build/sql/init.sql
+++ b/developments_build/sql/init.sql
@@ -123,16 +123,14 @@ in INIT_devdb will be the uid
 WITH latest_records AS (
 	SELECT
         job_number, 
-        geo_bbl, 
         MAX(date_lastupdt) AS date_lastupdt
 	FROM INIT_devdb
-	GROUP BY job_number, geo_bbl
+	GROUP BY job_number
 	HAVING COUNT(*)>1
 )
 DELETE FROM INIT_devdb a
 USING latest_records b
 WHERE a.job_number = b.job_number
-AND a.geo_bbl = b.geo_bbl
 AND a.date_lastupdt != b.date_lastupdt;
 
 /* 


### PR DESCRIPTION
#327 

Removing the `geo_bbl` match constraint resolves the remaining two duplicate job numbers. Prior to merging, we need to consider whether having identical job_numbers with different BBLs are ever relevant, or if they should always be considered as duplicates.

If there are cases where matching job_numbers with different BBLs are NOT duplicates, these two cases should instead get removed through manual corrections.