### PR TITLE
NULL out units after corrected resid_flag

### DIFF
--- a/developments_build/02_build_devdb.sh
+++ b/developments_build/02_build_devdb.sh
@@ -45,19 +45,19 @@ count CO_devdb
 
 display "Creating OCC fields: 
       occ_initial, 
-      occ_proposed, 
-      resid_flag, 
-      nonres_flag"
+      occ_proposed"
 psql $BUILD_ENGINE -f sql/_occ.sql
 count OCC_devdb
 
-display "Creating UNITS fields: classa_init,
-      classa_prop,
-      hotel_init,
-      hotel_prop,
-      otherb_init,
-      otherb_prop,
-      classa_net"
+display "Creating temp UNITS fields: _classa_init,
+      _classa_prop,
+      _hotel_init,
+      _hotel_prop,
+      _otherb_init,
+      _otherb_prop,
+      _classa_net,
+      resid_flag, 
+      nonres_flag"
 psql $BUILD_ENGINE -f sql/_units.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_units.sql
 count UNITS_devdb
@@ -93,7 +93,15 @@ psql $BUILD_ENGINE\
   -v CAPTURE_DATE_PREV=$CAPTURE_DATE_PREV\
   -f sql/qaqc/qaqc_status.sql
 
-display "Comining _MID_devdb with STATUS_devdb to create MID_devdb"
+display "Combining _MID_devdb with STATUS_devdb to create MID_devdb"
+display "Creating final UNITS fields:
+      classa_init,
+      classa_prop,
+      hotel_init,
+      hotel_prop,
+      otherb_init,
+      otherb_prop,
+      classa_net"
 psql $BUILD_ENGINE -f sql/mid.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_mid.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_geo.sql

--- a/developments_build/sql/_init.sql
+++ b/developments_build/sql/_init.sql
@@ -18,8 +18,8 @@ OUTPUTS:
 		stories_prop text,
 		zoningsft_init numeric,
 		zoningsft_prop numeric,
-		classa_init numeric,
-		classa_prop numeric,
+		_classa_init numeric,
+		_classa_prop numeric,
 		_job_status text,
 		date_lastupdt text,
 		date_filed text,
@@ -142,13 +142,13 @@ JOBNUMBER_relevant as (
         (CASE WHEN jobtype ~* 'NB' THEN 0 
         ELSE (CASE WHEN existingdwellingunits ~ '[^0-9]' THEN NULL
             ELSE existingdwellingunits::numeric END)
-    END) as classa_init,
+    END) as _classa_init,
 
     -- if proposeddwellingunits is not a number then null
 	(CASE WHEN jobtype ~* 'DM' THEN 0
 		ELSE (CASE WHEN proposeddwellingunits ~ '[^0-9]' THEN NULL
 			ELSE proposeddwellingunits::numeric END)
-	END) as classa_prop,
+	END) as _classa_prop,
 
 	-- one to one mappings
 	jobstatusdesc as _job_status,

--- a/developments_build/sql/_mid.sql
+++ b/developments_build/sql/_mid.sql
@@ -26,13 +26,13 @@ INPUTS:
 
     UNITS_devdb (
         * job_number,
-        classa_init,
-        classa_prop,
-        hotel_init,
-	    hotel_prop,
-	    otherb_init,
-	    otherb_prop,
-        classa_net
+        _classa_init,
+        _classa_prop,
+        _hotel_init,
+	    _hotel_prop,
+	    _otherb_init,
+	    _otherb_prop,
+        _classa_net
     )
 
     OCC_devdb (
@@ -216,26 +216,26 @@ JOIN_units as (
         a.*,
         extract(year from date_complete)::text as complete_year,
         year_quarter(date_complete) as complete_qrtr,
-        b.classa_init,
-        b.classa_prop,
-        b.classa_net,
-        b.hotel_init,
-	    b.hotel_prop,
-	    b.otherb_init,
-	    b.otherb_prop,
+        b._classa_init,
+        b._classa_prop,
+        b._classa_net,
+        b._hotel_init,
+	    b._hotel_prop,
+	    b._otherb_init,
+	    b._otherb_prop,
         (CASE
-            WHEN b.classa_net != 0 
-                THEN a.co_latest_units/b.classa_net
+            WHEN b._classa_net != 0 
+                THEN a.co_latest_units/b._classa_net
             ELSE NULL
         END) as classa_complt_pct,
-        b.classa_net - a.co_latest_units as classa_complt_diff,
+        b._classa_net - a.co_latest_units as classa_complt_diff,
         (CASE 
-            WHEN (hotel_init IS NOT NULL AND hotel_init <> '0')
-                OR (hotel_prop IS NOT NULL AND hotel_prop <> '0')
-                OR (otherb_init IS NOT NULL AND otherb_init <> '0')
-                OR (otherb_prop IS NOT NULL AND otherb_prop <> '0')
-                OR (classa_init IS NOT NULL AND classa_init <> '0')
-                OR (classa_prop IS NOT NULL AND classa_prop <> '0')
+            WHEN (_hotel_init IS NOT NULL AND _hotel_init <> '0')
+                OR (_hotel_prop IS NOT NULL AND _hotel_prop <> '0')
+                OR (_otherb_init IS NOT NULL AND _otherb_init <> '0')
+                OR (_otherb_prop IS NOT NULL AND _otherb_prop <> '0')
+                OR (_classa_init IS NOT NULL AND _classa_init <> '0')
+                OR (_classa_prop IS NOT NULL AND _classa_prop <> '0')
                 THEN 'Residential' 
         END) as resid_flag
     FROM JOIN_co a

--- a/developments_build/sql/_units.sql
+++ b/developments_build/sql/_units.sql
@@ -2,15 +2,15 @@
 /*
 DESCRIPTION:
     This script assigns units fields for devdb
-	1. Assign classa_init and classa_prop
-	2. Apply corrections to classa_init and classa_prop
-	3. Assign classa_net
+	1. Assign _classa_init and classa_prop
+	2. Apply corrections to _classa_init and classa_prop
+	3. Assign _classa_net
 INPUTS: 
 	INIT_devdb (
 		job_number text,
 		job_type text,
-		classa_init numeric,
-		classa_prop numeric
+		_classa_init numeric,
+		_classa_prop numeric
 	)
 	OCC_devdb (
 		job_number text,
@@ -20,13 +20,13 @@ INPUTS:
 OUTPUTS:
 	UNITS_devdb (
 		job_number text, 
-		classa_init numeric,
-		classa_prop numeric,
-		hotel_init numeric,
-		hotel_prop numeric,
-		otherb_init numeric,
-		otherb_prop numeric,
-		classa_net numeric
+		_classa_init numeric,
+		_classa_prop numeric,
+		_hotel_init numeric,
+		_hotel_prop numeric,
+		_otherb_init numeric,
+		_otherb_prop numeric,
+		_classa_net numeric
 	)
 IN PREVIOUS VERSION: 
     units_.sql
@@ -39,24 +39,24 @@ SELECT DISTINCT
 	a.job_type,
 	b.occ_proposed,
 	b.occ_initial,
-	a.classa_init,
-	a.classa_prop,
+	a._classa_init,
+	a._classa_prop,
 	(CASE
 		WHEN a.job_type = 'New Building' THEN 0
 		ELSE NULL
-	END) as hotel_init,
+	END) as _hotel_init,
 	(CASE
 		WHEN a.job_type = 'Demolition' THEN 0
 		ELSE NULL
-	END) as hotel_prop,
+	END) as _hotel_prop,
 	(CASE
 		WHEN a.job_type = 'New Building' THEN 0
 		ELSE NULL
-	END) as otherb_init,
+	END) as _otherb_init,
 	(CASE
 		WHEN a.job_type = 'Demolition' THEN 0
 		ELSE NULL
-	END) as otherb_prop
+	END) as _otherb_prop
 INTO _UNITS_devdb
 FROM INIT_devdb a
 LEFT JOIN OCC_devdb b
@@ -78,8 +78,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number=b.job_number
 	AND b.field = 'hotel_init'
-	AND (a.classa_init=b.old_value::numeric 
-		OR (a.classa_init IS NULL 
+	AND (a._classa_init=b.old_value::numeric 
+		OR (a._classa_init IS NULL 
 			AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -88,7 +88,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET hotel_init = b.new_value::numeric
+SET _hotel_init = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'hotel_init'
@@ -105,8 +105,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number = b.job_number
 	AND b.field = 'hotel_prop'
-	AND (a.classa_prop = b.old_value::numeric 
-		OR (a.classa_prop IS NULL 
+	AND (a._classa_prop = b.old_value::numeric 
+		OR (a._classa_prop IS NULL 
 		AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -115,7 +115,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET hotel_prop = b.new_value::numeric
+SET _hotel_prop = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'hotel_prop'
@@ -132,8 +132,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number=b.job_number
 	AND b.field = 'otherb_init'
-	AND (a.classa_init=b.old_value::numeric 
-		OR (a.classa_init IS NULL 
+	AND (a._classa_init=b.old_value::numeric 
+		OR (a._classa_init IS NULL 
 			AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -142,7 +142,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET otherb_init = b.new_value::numeric
+SET _otherb_init = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'otherb_init'
@@ -159,8 +159,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number = b.job_number
 	AND b.field = 'otherb_prop'
-	AND (a.classa_prop = b.old_value::numeric 
-		OR (a.classa_prop IS NULL 
+	AND (a._classa_prop = b.old_value::numeric 
+		OR (a._classa_prop IS NULL 
 		AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -169,7 +169,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET otherb_prop = b.new_value::numeric
+SET _otherb_prop = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'otherb_prop'
@@ -186,8 +186,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number=b.job_number
 	AND b.field = 'classa_init'
-	AND (a.classa_init=b.old_value::numeric 
-		OR (a.classa_init IS NULL 
+	AND (a._classa_init=b.old_value::numeric 
+		OR (a._classa_init IS NULL 
 			AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -196,7 +196,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET classa_init = b.new_value::numeric
+SET _classa_init = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'classa_init'
@@ -213,8 +213,8 @@ WITH CORR_target as (
 	FROM _UNITS_devdb a, housing_input_research b
 	WHERE a.job_number = b.job_number
 	AND b.field = 'classa_prop'
-	AND (a.classa_prop = b.old_value::numeric 
-		OR (a.classa_prop IS NULL 
+	AND (a._classa_prop = b.old_value::numeric 
+		OR (a._classa_prop IS NULL 
 		AND b.old_value IS NULL))
 )
 UPDATE CORR_devdb a
@@ -223,7 +223,7 @@ FROM CORR_target b
 WHERE a.job_number=b.job_number;
 
 UPDATE _UNITS_devdb a
-SET classa_prop = b.new_value::numeric
+SET _classa_prop = b.new_value::numeric
 FROM housing_input_research b
 WHERE a.job_number=b.job_number
 AND b.field = 'classa_prop'
@@ -240,14 +240,14 @@ SELECT
 	*,
 	(CASE
 		WHEN job_type = 'Demolition' 
-			THEN classa_init * -1
+			THEN _classa_init * -1
 		WHEN job_type = 'New Building' 
-			THEN classa_prop
+			THEN _classa_prop
 		WHEN job_type = 'Alteration' 
-			AND classa_init IS NOT NULL 
-			AND classa_prop IS NOT NULL 
-			THEN classa_prop - classa_init
+			AND _classa_init IS NOT NULL 
+			AND _classa_prop IS NOT NULL 
+			THEN _classa_prop - _classa_init
 		ELSE NULL
-	END) as classa_net
+	END) as _classa_net
 INTO UNITS_devdb
 FROM _UNITS_devdb;

--- a/developments_build/sql/mid.sql
+++ b/developments_build/sql/mid.sql
@@ -24,6 +24,13 @@ INPUTS:
 OUTPUTS: 
     MID_STATUS_devdb (
         * job_number,
+        classa_init int,
+        classa_prop int,
+        classa_net int,
+        hotel_init int,
+        hotel_prop int,
+        otherb_init int,
+        otherb_prop int,
         job_status character varying,
         complete_year text,
         complete_qrtr text,
@@ -37,6 +44,34 @@ WITH
 JOIN_STATUS_devdb as (
     SELECT
         a.*,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._classa_init
+        END) as classa_init,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._classa_prop
+        END) as classa_prop,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._classa_net
+        END) as classa_net,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._hotel_init
+        END) as hotel_init,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._hotel_prop
+        END) as hotel_prop,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._otherb_init
+        END) as otherb_init,
+        (CASE
+            WHEN a.resid_flag IS NULL THEN NULL
+            ELSE a._otherb_prop
+        END) as otherb_prop,
         b.job_status,
         b.job_inactive
     FROM _MID_devdb a

--- a/developments_build/sql/qaqc/qaqc_units.sql
+++ b/developments_build/sql/qaqc/qaqc_units.sql
@@ -13,7 +13,7 @@ JOBNUMBER_large_alt AS(
     FROM UNITS_devdb
     WHERE
     job_type = 'Alteration'
-    AND classa_net::numeric < -5
+    AND _classa_net::numeric < -5
 ),
 
 JOBNUMBER_large_nb AS(
@@ -21,7 +21,7 @@ JOBNUMBER_large_nb AS(
     FROM UNITS_devdb
     WHERE
     job_type = 'New Building'
-    AND classa_prop::numeric > 499
+    AND _classa_prop::numeric > 499
 ),
 
 JOBNUMBER_large_demo AS(
@@ -29,7 +29,7 @@ JOBNUMBER_large_demo AS(
     FROM UNITS_devdb
     WHERE
     job_type = 'Demolition'
-    AND classa_init::numeric > 19
+    AND _classa_init::numeric > 19
 ),
 
 JOBNUMBER_top_alt_inc AS(
@@ -37,8 +37,8 @@ JOBNUMBER_top_alt_inc AS(
     FROM UNITS_devdb
     WHERE
     job_type = 'Alteration'
-    AND classa_net IS NOT NULL
-    ORDER BY classa_net DESC
+    AND _classa_net IS NOT NULL
+    ORDER BY _classa_net DESC
     LIMIT 20
 ),
 
@@ -47,8 +47,8 @@ JOBNUMBER_top_alt_dec AS(
     FROM UNITS_devdb
     WHERE
     job_type = 'Alteration'
-    AND classa_net IS NOT NULL
-    ORDER BY classa_net ASC
+    AND _classa_net IS NOT NULL
+    ORDER BY _classa_net ASC
     LIMIT 20
 )
 


### PR DESCRIPTION
#367 

Because we need to wait until corrections to resid flag, all unit fields are temporary until creating MID_devdb