### PR TITLE
Stop joining million bins to geographies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
           version: ${{ steps.version.outputs.version }}
       
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
           service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         github.event_name == 'push' &&
         ! contains(github.event.head_commit.message, '[skip]')
       ) || github.event_name != 'push'
-    runs-on: self-hosted
+    runs-on: ubuntu-20.04
     services:
       db:
         image: postgis/postgis:11-3.0-alpine

--- a/sql/_geo.sql
+++ b/sql/_geo.sql
@@ -132,6 +132,7 @@ GEOM_dob_bin_bldgfootprints as (
         END) as geomsource
     FROM DRAFT a
     LEFT JOIN doitt_buildingfootprints b
+    WHERE b.bin IS NOT LIKE '%000000'
     ON a.bin::text = b.bin::numeric::bigint::text
 ),
 GEOM_geo_bin_bldgfootprints as (
@@ -154,6 +155,7 @@ GEOM_geo_bin_bldgfootprints as (
 		END) as geomsource
     FROM GEOM_dob_bin_bldgfootprints a
     LEFT JOIN doitt_buildingfootprints b
+    WHERE b.bin IS NOT LIKE '%000000'
     ON a.geo_bin::text = b.bin::numeric::bigint::text
 ),
 GEOM_geosupport as (

--- a/sql/_geo.sql
+++ b/sql/_geo.sql
@@ -76,6 +76,7 @@ DRAFT as (
         a.uid,
         a.job_number,
 		a.bbl,
+        -- a.bin,
         (CASE 
             WHEN RIGHT(a.bin,6) = '000000' THEN NULL
             ELSE a.bin
@@ -135,8 +136,8 @@ GEOM_dob_bin_bldgfootprints as (
         END) as geomsource
     FROM DRAFT a
     LEFT JOIN doitt_buildingfootprints b
-    WHERE b.bin IS NOT LIKE '%000000'
     ON a.bin::text = b.bin::numeric::bigint::text
+    -- WHERE RIGHT(b.bin::text, 6) != '000000'
 ),
 GEOM_geo_bin_bldgfootprints as (
 	SELECT distinct
@@ -158,8 +159,8 @@ GEOM_geo_bin_bldgfootprints as (
 		END) as geomsource
     FROM GEOM_dob_bin_bldgfootprints a
     LEFT JOIN doitt_buildingfootprints b
-    WHERE b.bin IS NOT LIKE '%000000'
     ON a.geo_bin::text = b.bin::numeric::bigint::text
+    -- WHERE RIGHT(b.bin::text, 6) != '000000'
 ),
 GEOM_geosupport as (
     SELECT distinct

--- a/sql/_geo.sql
+++ b/sql/_geo.sql
@@ -76,7 +76,10 @@ DRAFT as (
         a.uid,
         a.job_number,
 		a.bbl,
-        a.bin,
+        (CASE 
+            WHEN RIGHT(a.bin,6) = '000000' THEN NULL
+            ELSE a.bin
+        END) as bin,
         a.date_lastupdt,
         a.job_desc,
         b.geo_bbl,

--- a/sql/_hny.sql
+++ b/sql/_hny.sql
@@ -357,12 +357,12 @@ WITH
                             one_hny_to_many_dev
 					FROM RELATEFLAGS_hny_matches
 					WHERE one_dev_to_many_hny = 1
-					GROUP BY job_number, one_dev_to_many_hny, one_hny_to_many_dev),
+					GROUP BY job_number, one_dev_to_many_hny, one_hny_to_many_dev), 
 
 	-- c) For multiple dev to one hny, assign units to the one with the lowest job_number
 	-- Find the minimum job_number per hny in RELATEFLAGS_hny_matches
 	min_job_number_per_hny AS 
-        (SELECT MIN(job_number::INT)::text AS job_number, hny_id
+        (SELECT MIN(job_number) AS job_number, hny_id
             FROM RELATEFLAGS_hny_matches
             WHERE one_hny_to_many_dev = 1
             GROUP BY hny_id),
@@ -428,6 +428,6 @@ SELECT a.job_number,
 INTO HNY_devdb
 FROM MID_devdb a
 LEFT JOIN HNY_lookup b
-ON a.job_number = b.job_number;
+ON a.job_number::text = b.job_number::text;
 
 

--- a/sql/_hny.sql
+++ b/sql/_hny.sql
@@ -428,6 +428,6 @@ SELECT a.job_number,
 INTO HNY_devdb
 FROM MID_devdb a
 LEFT JOIN HNY_lookup b
-ON a.job_number::text = b.job_number::text;
+ON a.job_number = b.job_number;
 
 


### PR DESCRIPTION
## Add case to join and fix downstream issues
The process we needed to replace million bins with null in the `DRAFT` CTE in `_geo.sql` was already applied in the select of `geo_bins`:
```sql
(CASE 
  WHEN RIGHT(b.geo_bin,6) = '000000' THEN NULL
  ELSE b.geo_bin
END) as geo_bin
```
When this was also applied to the `bin` field then the million bins were no longer joined in `_geo.sql`

This allowed the `_mid.sql` file to execute but another bug was found in `_hny.sql`. A record with a job number with a leading "B" made it into `RELATEFLAGS_hny_matches` CTE in `_hny.sql`. This caused an error when code to identify a single job number per hny record casted job numbers to int. It did this to call `MIN()` on the job number column in a group by. Fortunately this cast was unnecessary as `MIN()` can take a text column and it's exact behavior doesn't matter as all we need is a single job number per record. 

The entire `02_build_devdb.sh` file was successfully run on my local environment after these changes but the entire build wasn't done. I don't have time to do whole build tonight, can do it on monday if that's best practice before merging 