### PR TITLE
readme data links fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2020.csv) |
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2020.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) |
-[ctda](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_ctda_2020.csv)
+[ctda](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_cdta_2020.csv)
 
 #### Aggregation Tables 2010 Geographies
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ Processing DOB Job Application and Certificate of Occupancy data to identify job
 CSV | [devdb.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.csv) | [housing.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.csv)
 Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.shp.zip) | [housing.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.shp.zip)
 
-#### Aggregation Tables
+#### Aggregation Tables 2010
 
-[block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_block.csv) |
-[tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract.csv) |
-[commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst.csv) |
-[councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst.csv) |
-[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta.csv) |
-[PUMA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_puma.csv)
+[block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_block_2010.csv) |
+[tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract_2010.csv) |
+[commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2010.csv) |
+[councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2010.csv) |
+[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2010.csv) |
+[PUMA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_puma_2010.csv)
 
 #### All files [bundle.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/output.zip)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2020.csv) |
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2020.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) |
-[PUMA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_puma_2020.csv)
+[ctda](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_ctda_2020.csv)
 
 #### Aggregation Tables 2010 Geographies
 
@@ -34,7 +34,6 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2010.csv) |
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2010.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2010.csv) |
-[PUMA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_puma_2010.csv)
 
 #### All files [bundle.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/output.zip)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ Processing DOB Job Application and Certificate of Occupancy data to identify job
 CSV | [devdb.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.csv) | [housing.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.csv)
 Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.shp.zip) | [housing.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.shp.zip)
 
-#### Aggregation Tables 2010
+#### Aggregation Tables 2020 Geographies
+
+[block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_block_2020.csv) |
+[tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract_2020.csv) |
+[commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2020.csv) |
+[councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2020.csv) |
+[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) |
+[PUMA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_puma_2020.csv)
+
+#### Aggregation Tables 2010 Geographies
 
 [block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_block_2010.csv) |
 [tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract_2010.csv) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2020.csv) |
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2020.csv) |
 [NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) |
-[ctda](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_cdta_2020.csv)
+[cdta](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_cdta_2020.csv)
 
 #### Aggregation Tables 2010 Geographies
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 
 [block](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_block_2020.csv) |
 [tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract_2020.csv) |
-[commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2020.csv) |
-[councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2020.csv) |
-[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) |
-[cdta](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_cdta_2020.csv)
+[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2020.csv) 
 
 #### Aggregation Tables 2010 Geographies
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Processing DOB Job Application and Certificate of Occupancy data to identify job
 
   | Devdb | HousingDB
 -- | -- | --
-CSV | [devdb.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/devdb.csv) | [housing.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/housing.csv)
-Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/devdb.shp.zip) | [housing.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/main/latest/output/housing.shp.zip)
+CSV | [devdb.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.csv) | [housing.csv](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.csv)
+Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/devdb.shp.zip) | [housing.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/housing.shp.zip)
 
 #### Aggregation Tables
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Shapefile | [devdb.shp.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/d
 [tract](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_tract_2010.csv) |
 [commntydst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_commntydst_2010.csv) |
 [councildst](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_councildst_2010.csv) |
-[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2010.csv) |
+[NTA](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/aggregate_nta_2010.csv)
 
 #### All files [bundle.zip](https://edm-publishing.nyc3.digitaloceanspaces.com/db-developments/latest/output/output.zip)
 


### PR DESCRIPTION
fix the data links in the README to point to the latest folder in edm-publishing for the qaqc tables

## Question
I believe in the last iteration of readme only 2010 aggregate tables exists so the aggregate links need to be updated. I did not include the new set of 2020 aggregate tables. Please let me know if this needs to be changed. 