### PR TITLE
add associative match query

### DIFF
--- a/sql/_hny.sql
+++ b/sql/_hny.sql
@@ -301,8 +301,8 @@ NOT IN (SELECT hny_id||job_number
 --- cross grouping of all hny_id and job between manual and other matching methods
 WITH associative_matches AS (
     SELECT a.job_number as j1, b.job_number as j2 
-    FROM hny_matches a 
-    FULL JOIN hny_matches b
+    FROM HNY_matches a 
+    FULL JOIN HNY_matches b
     ON a.hny_id = b.hny_id 
     WHERE a.job_number <> b.job_number)
 INSERT INTO HNY_matches(hny_id, hny_project_id, job_number, total_units, all_counted_units)

--- a/sql/_hny.sql
+++ b/sql/_hny.sql
@@ -300,7 +300,7 @@ NOT IN (SELECT hny_id||job_number
 
 --- cross grouping of all hny_id and job between manual and other matching methods
 WITH associative_matches AS (
-    SELECT a.job_number as j1, b.job_number as j2 
+    SELECT DISTINCT a.job_number||b.job_number, a.job_number as j1, b.job_number as j2 
     FROM HNY_matches a 
     FULL JOIN HNY_matches b
     ON a.hny_id = b.hny_id 


### PR DESCRIPTION
For more details on issue see #504 

## Solution
Since the issue was with the matches from are not effectively grouping together and causing failed joins down the line due to logical contradiction. I figure the easies solution would be to make sure the grouping between all methods and add the missing matches to the `HNY_matches`. Not sure my query is the most elegant in terms of creating the associative table but it did seems to work now the build step can run to end without issue and does seems the `HNY_matches` table is updated with all the `hny_id` and `job_number` matches. 

## Next step
Once this is merged into the feature branch we can turn our attention to merge in the #501. And we should be almost ready for a production run. Thanks!