### PR TITLE
Add in units mismatch check

### DIFF
--- a/bash/02_build_devdb.sh
+++ b/bash/02_build_devdb.sh
@@ -105,4 +105,7 @@ display "Creating FINAL_devdb and formatted QAQC table"
 psql $BUILD_ENGINE -v VERSION=$VERSION  -f sql/final.sql
 psql $BUILD_ENGINE -f sql/corrections.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_final.sql
+
+display "Creating QAQC Table for QAQC Application"
+psql $BUILD_ENGINE -f sql/qaqc/qaqc_app_units.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_app.sql

--- a/bash/02_build_devdb.sh
+++ b/bash/02_build_devdb.sh
@@ -107,5 +107,5 @@ psql $BUILD_ENGINE -f sql/corrections.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_final.sql
 
 display "Creating QAQC Table for QAQC Application"
-psql $BUILD_ENGINE -f sql/qaqc/qaqc_app_units.sql
+psql $BUILD_ENGINE -f sql/qaqc/qaqc_app_additions.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_app.sql

--- a/sql/qaqc/qaqc_app.sql
+++ b/sql/qaqc/qaqc_app.sql
@@ -29,12 +29,12 @@ SELECT
     HPD_review.invalid_date_statusx,
     HPD_review.incomp_tract_home,
     HPD_review.dem_nb_overlap,
-    qaqc_app_units.classa_net_mismatch 
+    qaqc_app_additions.classa_net_mismatch
 INTO qaqc_app
 FROM
     FINAL_qaqc HPD_review
-LEFT JOIN qaqc_app_units
-ON HPD_review.job_number = qaqc_app_units.job_number
+LEFT JOIN qaqc_app_additions
+ON HPD_review.job_number = qaqc_app_additions.job_number
 WHERE
     HPD_review.b_likely_occ_desc = 1
     OR HPD_review.b_large_alt_reduction = 1
@@ -62,4 +62,4 @@ WHERE
     OR HPD_review.dup_bbl_address_units IS NOT NULL
     OR HPD_review.dup_bbl_address IS NOT NULL
     OR HPD_review.units_co_prop_mismatch IS NOT NULL
-    OR qaqc_app_units.classa_net_mismatch = 1;
+    OR qaqc_app_additions.classa_net_mismatch = 1;

--- a/sql/qaqc/qaqc_app.sql
+++ b/sql/qaqc/qaqc_app.sql
@@ -28,10 +28,13 @@ SELECT
     HPD_review.invalid_date_statusr,
     HPD_review.invalid_date_statusx,
     HPD_review.incomp_tract_home,
-    HPD_review.dem_nb_overlap 
+    HPD_review.dem_nb_overlap,
+    qaqc_app_units.classa_net_mismatch 
 INTO qaqc_app
 FROM
     FINAL_qaqc HPD_review
+LEFT JOIN qaqc_app_units
+ON HPD_review.job_number = qaqc_app_units.job_number
 WHERE
     HPD_review.b_likely_occ_desc = 1
     OR HPD_review.b_large_alt_reduction = 1
@@ -58,4 +61,5 @@ WHERE
     OR HPD_review.dem_nb_overlap = 1
     OR HPD_review.dup_bbl_address_units IS NOT NULL
     OR HPD_review.dup_bbl_address IS NOT NULL
-    OR HPD_review.units_co_prop_mismatch IS NOT NULL;
+    OR HPD_review.units_co_prop_mismatch IS NOT NULL
+    OR qaqc_app_units.classa_net_mismatch = 1;

--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS qaqc_app_units;
+DROP TABLE IF EXISTS qaqc_app_additions;
 WITH 
 classa_net_mismatch AS (
     SELECT job_number
@@ -13,5 +13,5 @@ SELECT a.job_number,
 	 	WHEN a.job_number IN (SELECT job_number FROM classa_net_mismatch) THEN 1
 	 	ELSE 0
 	END) as classa_net_mismatch
-INTO qaqc_app_units
-FROM FINAL_qaqc a;
+INTO qaqc_app_additions
+FROM FINAL_devdb a;

--- a/sql/qaqc/qaqc_app_units.sql
+++ b/sql/qaqc/qaqc_app_units.sql
@@ -1,0 +1,17 @@
+DROP TABLE IF EXISTS qaqc_app_units;
+WITH 
+classa_net_mismatch AS (
+    SELECT job_number
+    FROM FINAL_devdb
+    WHERE
+    classa_init IS NOT NULL
+    AND classa_prop IS NOT NULL
+    AND classa_net <> classa_prop - classa_init
+)
+SELECT a.job_number,
+    (CASE 
+	 	WHEN a.job_number IN (SELECT job_number FROM classa_net_mismatch) THEN 1
+	 	ELSE 0
+	END) as classa_net_mismatch
+INTO qaqc_app_units
+FROM FINAL_qaqc a;


### PR DESCRIPTION
Adds in check for classa_net mismatch. Two things I wasn't sure about:

1. Should the new file for adding new app specific qaqc checks be less specific, or should we plan on being more liberal with file creation?
2. This follows the existing pattern of checks being binary fields across the entire table - pretty space intensive for an intermediate step. Should I move to instead only store the records with flags?