### PR TITLE
One-off create historic QAQC - DON'T MERGE

### DIFF
--- a/bash/construct_historic_qaqc_summary.sh
+++ b/bash/construct_historic_qaqc_summary.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+source bash/config.sh
+
+function import_QAQC {
+  version=$1
+
+  target_dir=$(pwd)/.library/qaqc/$version
+  qaqc_do_path=spaces/edm-publishing/db-developments/$version/output/FINAL_qaqc.csv
+  if [ -f $target_dir/FINAL_qaqc.csv ]; then
+    echo "✅ $version exists in cache"
+  else
+    echo "🛠 $version doesn't exists in cache, downloading ..."
+    mkdir -p $target_dir && (
+      cd $target_dir
+      mc cp $qaqc_do_path FINAL_qaqc.csv
+    )
+  fi
+}
+
+function load_to_DB {
+    psql $BUILD_ENGINE -f sql/qaqc/qaqc_historic.sql
+}
+
+
+
+for version in 20Q2 20Q4 21Q2 21Q4 
+do 
+ import_QAQC $version
+done
+
+load_to_DB 
+
+mkdir -p output 
+(
+    cd output
+    psql $BUILD_ENGINE -c "\COPY ( 
+        SELECT * FROM qaqc_historic
+      ) TO STDOUT DELIMITER ',' CSV HEADER;" > qaqc_historic.csv
+    pg_dump -d $BUILD_ENGINE -t qaqc_historic -f qaqc_historic.sql  
+)

--- a/output/qaqc_historic.csv
+++ b/output/qaqc_historic.csv
@@ -1,0 +1,5 @@
+version,b_likely_occ_desc,b_large_alt_reduction,b_nonres_with_units,units_co_prop_mismatch,partially_complete,units_init_null,units_prop_null,units_res_accessory,outlier_demo_20plus,outlier_nb_500plus,outlier_top_alt_increase,dup_bbl_address_units,dup_bbl_address,inactive_with_update,no_work_job,geo_water,geo_taxlot,geo_null_latlong,geo_null_boundary,invalid_date_filed,invalid_date_lastupdt,invalid_date_statusd,invalid_date_statusp,invalid_date_statusr,invalid_date_statusx,incomp_tract_home,dem_nb_overlap
+20Q2,,,,,,,,,,,,,,,,,,,,,,,,,,,
+20Q4,4334,600,10393,1119,13,43810,234,6824,116,95,20,1920,52395,0,15574,0,1537,553,1774,0,0,0,2,0,1,3532,65359
+21Q2,6660,715,103626,1141,16,43787,235,7097,119,100,20,655647,1883333,0,15997,0,2261,819,2312,0,0,0,2,0,1,3531,66659
+21Q4,4018,684,10572,1075,5,39483,61,5332,121,108,20,1934,52943,9,15927,217,993,160,1661,0,0,0,1,0,1,3525,68076

--- a/output/qaqc_historic.sql
+++ b/output/qaqc_historic.sql
@@ -1,0 +1,76 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.4 (Debian 13.4-4.pgdg110+1)
+-- Dumped by pg_dump version 14.0
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: qaqc_historic; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.qaqc_historic (
+    version text,
+    b_likely_occ_desc integer,
+    b_large_alt_reduction integer,
+    b_nonres_with_units integer,
+    units_co_prop_mismatch integer,
+    partially_complete integer,
+    units_init_null integer,
+    units_prop_null integer,
+    units_res_accessory integer,
+    outlier_demo_20plus integer,
+    outlier_nb_500plus integer,
+    outlier_top_alt_increase integer,
+    dup_bbl_address_units integer,
+    dup_bbl_address integer,
+    inactive_with_update integer,
+    no_work_job integer,
+    geo_water integer,
+    geo_taxlot integer,
+    geo_null_latlong integer,
+    geo_null_boundary integer,
+    invalid_date_filed integer,
+    invalid_date_lastupdt integer,
+    invalid_date_statusd integer,
+    invalid_date_statusp integer,
+    invalid_date_statusr integer,
+    invalid_date_statusx integer,
+    incomp_tract_home integer,
+    dem_nb_overlap integer
+);
+
+
+ALTER TABLE public.qaqc_historic OWNER TO postgres;
+
+--
+-- Data for Name: qaqc_historic; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.qaqc_historic (version, b_likely_occ_desc, b_large_alt_reduction, b_nonres_with_units, units_co_prop_mismatch, partially_complete, units_init_null, units_prop_null, units_res_accessory, outlier_demo_20plus, outlier_nb_500plus, outlier_top_alt_increase, dup_bbl_address_units, dup_bbl_address, inactive_with_update, no_work_job, geo_water, geo_taxlot, geo_null_latlong, geo_null_boundary, invalid_date_filed, invalid_date_lastupdt, invalid_date_statusd, invalid_date_statusp, invalid_date_statusr, invalid_date_statusx, incomp_tract_home, dem_nb_overlap) FROM stdin;
+20Q2	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N	\N
+20Q4	4334	600	10393	1119	13	43810	234	6824	116	95	20	1920	52395	0	15574	0	1537	553	1774	0	0	0	2	0	1	3532	65359
+21Q2	6660	715	103626	1141	16	43787	235	7097	119	100	20	655647	1883333	0	15997	0	2261	819	2312	0	0	0	2	0	1	3531	66659
+21Q4	4018	684	10572	1075	5	39483	61	5332	121	108	20	1934	52943	9	15927	217	993	160	1661	0	0	0	1	0	1	3525	68076
+\.
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/sql/qaqc/qaqc_historic.sql
+++ b/sql/qaqc/qaqc_historic.sql
@@ -1,0 +1,308 @@
+
+DROP TABLE IF EXISTS qaqc_historic;
+create table qaqc_historic(
+    version text,
+    b_likely_occ_desc integer,
+    b_large_alt_reduction integer,
+    b_nonres_with_units integer,
+    units_co_prop_mismatch integer,
+    partially_complete integer,
+    units_init_null integer,
+    units_prop_null integer,
+    units_res_accessory integer,
+    outlier_demo_20plus integer,
+    outlier_nb_500plus integer,
+    outlier_top_alt_increase integer,
+    dup_bbl_address_units integer,
+    dup_bbl_address integer,
+    inactive_with_update integer,
+    no_work_job integer,
+    geo_water integer,
+    geo_taxlot integer,
+    geo_null_latlong integer,
+    geo_null_boundary integer,
+    invalid_date_filed integer,
+    invalid_date_lastupdt integer,
+    invalid_date_statusd integer,
+    invalid_date_statusp integer,
+    invalid_date_statusr integer,
+    invalid_date_statusx integer,
+    incomp_tract_home integer,
+    dem_nb_overlap integer
+);
+
+-- 20Q2
+DROP TABLE IF EXISTS qaqc_20Q2;
+
+create table qaqc_20Q2(
+    b_likely_occ_desc text,
+    b_large_alt_reduction text,
+    b_nonres_with_units text,
+    units_co_prop_mismatch text,
+    partially_complete text,
+    units_init_null text,
+    units_prop_null text,
+    units_res_accessory text,
+    outlier_demo_20plus text,
+    outlier_nb_500plus text,
+    outlier_top_alt_increase text,
+    dup_bbl_address_units text,
+    dup_bbl_address text,
+    inactive_with_update text,
+    no_work_job text,
+    geo_water text,
+    geo_taxlot text,
+    geo_null_latlong text,
+    geo_null_boundary text,
+    invalid_date_filed text,
+    invalid_date_lastupdt text,
+    invalid_date_statusd text,
+    invalid_date_statusp text,
+    invalid_date_statusr text,
+    invalid_date_statusx text,
+    incomp_tract_home text,
+    dem_nb_overlap text
+);
+
+\COPY qaqc_20Q2 FROM '.library/qaqc/20Q2/FINAL_qaqc.csv' DELIMITER ',' CSV HEADER;
+
+INSERT INTO qaqc_historic(
+SELECT
+    '20Q2',
+    SUM(CASE WHEN b_likely_occ_desc != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_large_alt_reduction != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_nonres_with_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_co_prop_mismatch != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN partially_complete != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_init_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_prop_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_res_accessory != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_demo_20plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_nb_500plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_top_alt_increase != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN inactive_with_update != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN no_work_job != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_water != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_taxlot != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_latlong != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_boundary != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_filed != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_lastupdt != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusd != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusp != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusr != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusx != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN incomp_tract_home != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dem_nb_overlap != '0' THEN 1 ELSE 0 END)
+FROM qaqc_20q2
+);
+
+-- 20Q4
+DROP TABLE IF EXISTS qaqc_20Q4;
+
+create table qaqc_20Q4(
+    b_likely_occ_desc text,
+    b_large_alt_reduction text,
+    b_nonres_with_units text,
+    units_co_prop_mismatch text,
+    partially_complete text,
+    units_init_null text,
+    units_prop_null text,
+    units_res_accessory text,
+    outlier_demo_20plus text,
+    outlier_nb_500plus text,
+    outlier_top_alt_increase text,
+    dup_bbl_address_units text,
+    dup_bbl_address text,
+    inactive_with_update text,
+    no_work_job text,
+    geo_water text,
+    geo_taxlot text,
+    geo_null_latlong text,
+    geo_null_boundary text,
+    invalid_date_filed text,
+    invalid_date_lastupdt text,
+    invalid_date_statusd text,
+    invalid_date_statusp text,
+    invalid_date_statusr text,
+    invalid_date_statusx text,
+    incomp_tract_home text,
+    dem_nb_overlap text
+);
+
+\COPY qaqc_20Q4 FROM '.library/qaqc/20Q4/FINAL_qaqc.csv' DELIMITER ',' CSV HEADER;
+
+INSERT INTO qaqc_historic(
+SELECT
+    '20Q4',
+    SUM(CASE WHEN b_likely_occ_desc != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_large_alt_reduction != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_nonres_with_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_co_prop_mismatch != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN partially_complete != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_init_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_prop_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_res_accessory != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_demo_20plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_nb_500plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_top_alt_increase != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN inactive_with_update != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN no_work_job != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_water != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_taxlot != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_latlong != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_boundary != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_filed != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_lastupdt != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusd != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusp != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusr != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusx != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN incomp_tract_home != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dem_nb_overlap != '0' THEN 1 ELSE 0 END)
+FROM qaqc_20q4
+);
+
+-- 21Q2
+
+DROP TABLE IF EXISTS qaqc_21Q2;
+
+create table qaqc_21Q2(
+    b_likely_occ_desc text,
+    b_large_alt_reduction text,
+    b_nonres_with_units text,
+    units_co_prop_mismatch text,
+    partially_complete text,
+    units_init_null text,
+    units_prop_null text,
+    units_res_accessory text,
+    outlier_demo_20plus text,
+    outlier_nb_500plus text,
+    outlier_top_alt_increase text,
+    dup_bbl_address_units text,
+    dup_bbl_address text,
+    inactive_with_update text,
+    no_work_job text,
+    geo_water text,
+    geo_taxlot text,
+    geo_null_latlong text,
+    geo_null_boundary text,
+    invalid_date_filed text,
+    invalid_date_lastupdt text,
+    invalid_date_statusd text,
+    invalid_date_statusp text,
+    invalid_date_statusr text,
+    invalid_date_statusx text,
+    incomp_tract_home text,
+    dem_nb_overlap text
+);
+
+\COPY qaqc_21Q2 FROM '.library/qaqc/21Q2/FINAL_qaqc.csv' DELIMITER ',' CSV HEADER;
+
+INSERT INTO qaqc_historic(
+SELECT
+    '21Q2',
+    SUM(CASE WHEN b_likely_occ_desc != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_large_alt_reduction != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_nonres_with_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_co_prop_mismatch != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN partially_complete != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_init_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_prop_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_res_accessory != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_demo_20plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_nb_500plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_top_alt_increase != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN inactive_with_update != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN no_work_job != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_water != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_taxlot != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_latlong != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_boundary != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_filed != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_lastupdt != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusd != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusp != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusr != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusx != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN incomp_tract_home != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dem_nb_overlap != '0' THEN 1 ELSE 0 END)
+FROM qaqc_21q2
+);
+
+
+-- 21Q4
+
+DROP TABLE IF EXISTS qaqc_21Q4;
+
+create table qaqc_21Q4(
+    job_number text,
+    b_likely_occ_desc text,
+    b_large_alt_reduction text,
+    b_nonres_with_units text,
+    units_co_prop_mismatch text,
+    partially_complete text,
+    units_init_null text,
+    units_prop_null text,
+    units_res_accessory text,
+    outlier_demo_20plus text,
+    outlier_nb_500plus text,
+    outlier_top_alt_increase text,
+    dup_bbl_address_units text,
+    dup_bbl_address text,
+    inactive_with_update text,
+    no_work_job text,
+    geo_water text,
+    geo_taxlot text,
+    geo_null_latlong text,
+    geo_null_boundary text,
+    invalid_date_filed text,
+    invalid_date_lastupdt text,
+    invalid_date_statusd text,
+    invalid_date_statusp text,
+    invalid_date_statusr text,
+    invalid_date_statusx text,
+    incomp_tract_home text,
+    dem_nb_overlap text
+);
+
+\COPY qaqc_21Q4 FROM '.library/qaqc/21Q4/FINAL_qaqc.csv' DELIMITER ',' CSV HEADER;
+
+INSERT INTO qaqc_historic(
+SELECT
+    '21Q4',
+    SUM(CASE WHEN b_likely_occ_desc != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_large_alt_reduction != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN b_nonres_with_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_co_prop_mismatch != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN partially_complete != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_init_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_prop_null != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN units_res_accessory != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_demo_20plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_nb_500plus != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN outlier_top_alt_increase != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address_units != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dup_bbl_address != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN inactive_with_update != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN no_work_job != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_water != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_taxlot != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_latlong != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN geo_null_boundary != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_filed != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_lastupdt != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusd != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusp != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusr != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN invalid_date_statusx != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN incomp_tract_home != '0' THEN 1 ELSE 0 END),
+    SUM(CASE WHEN dem_nb_overlap != '0' THEN 1 ELSE 0 END)
+FROM qaqc_21q4
+)


### PR DESCRIPTION
❌ No merge ❌ 
This PR has code to create the historic QAQC table that we will append rows to in future production and testing runs of devDB. The approach is similar to the [pluto QAQC](https://github.com/NYCPlanning/db-pluto/blob/main/pluto_build/05_qaqc.sh), where files are pulled down from main and uploaded with a new row appended.


After this PR is approved I will upload the `.sql` and `.csv` file to DO. I opened issue #522 to ask a question on how we should write to DO, think this is a question for @AmandaDoyle.

Then I will open another PR that will be merged that has code to pull down the table from DO and add a single row for the current version. 

The .sql logic in `qaqc_historic.sql` I wrote is very repetitive, I couldn't figure out how to set the filepath to the csv or the table name from a variable so I copy/pasted 3 times. 😢 
The code I wrote to sum each column and insert to qaqc_historic will be the basis of the query that gets merged in on the next PR

Note that 21Q2 is empty, I kept it in because it is a published version and I thought we may want to explicitly store that there is no data for this version but maybe that's silly