### PR TITLE
add file for qaqc field distribution reports

### DIFF
--- a/bash/02_build_devdb.sh
+++ b/bash/02_build_devdb.sh
@@ -105,6 +105,10 @@ display "Creating FINAL_devdb and formatted QAQC table"
 psql $BUILD_ENGINE -v VERSION=$VERSION  -f sql/final.sql
 psql $BUILD_ENGINE -f sql/corrections.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_final.sql
+
+display "Creating QAQC Table for QAQC Application"
+psql $BUILD_ENGINE -f sql/qaqc/qaqc_app_additions.sql
+psql $BUILD_ENGINE -f sql/qaqc/qaqc_app.sql
 psql $BUILD_ENGINE\
    -v CAPTURE_DATE_PREV=$CAPTURE_DATE_PREV\
    -f sql/qaqc/qaqc_field_distribution.sql

--- a/bash/02_build_devdb.sh
+++ b/bash/02_build_devdb.sh
@@ -105,3 +105,4 @@ display "Creating FINAL_devdb and formatted QAQC table"
 psql $BUILD_ENGINE -v VERSION=$VERSION  -f sql/final.sql
 psql $BUILD_ENGINE -f sql/corrections.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_final.sql
+psql $BUILD_ENGINE -v PRE_DATE=$CAPTURE_DATE_PREV -f sql/qaqc/qaqc_field_distribution.sql

--- a/bash/02_build_devdb.sh
+++ b/bash/02_build_devdb.sh
@@ -105,4 +105,6 @@ display "Creating FINAL_devdb and formatted QAQC table"
 psql $BUILD_ENGINE -v VERSION=$VERSION  -f sql/final.sql
 psql $BUILD_ENGINE -f sql/corrections.sql
 psql $BUILD_ENGINE -f sql/qaqc/qaqc_final.sql
-psql $BUILD_ENGINE -v PRE_DATE=$CAPTURE_DATE_PREV -f sql/qaqc/qaqc_field_distribution.sql
+psql $BUILD_ENGINE\
+   -v CAPTURE_DATE_PREV=$CAPTURE_DATE_PREV\
+   -f sql/qaqc/qaqc_field_distribution.sql

--- a/bash/03_export.sh
+++ b/bash/03_export.sh
@@ -20,7 +20,8 @@ mkdir -p output
     
     display "Export QAQC Tables"
     CSV_export FINAL_qaqc &
-    CSV_export HNY_no_match
+    CSV_export HNY_no_match &
+    CSV_export qaqc_field_distribution &
     
     display "Export Corrections"
     CSV_export CORR_hny_matches &

--- a/bash/03_export.sh
+++ b/bash/03_export.sh
@@ -21,6 +21,7 @@ mkdir -p output
     display "Export QAQC Tables"
     CSV_export FINAL_qaqc &
     CSV_export HNY_no_match &
+    CSV_export qaqc_app &
     CSV_export qaqc_field_distribution &
     
     display "Export Corrections"

--- a/sql/qaqc/qaqc_field_distribution.sql
+++ b/sql/qaqc/qaqc_field_distribution.sql
@@ -10,7 +10,8 @@ INSERT INTO field_dist_qaqc (
     FROM(
         SELECT job_type, COUNT(DISTINCT job_number) as count
         FROM final_devdb
-        WHERE date_lastupdt >= CAST(:PRE_DATE AS VARCHAR)
+        WHERE is_date(date_lastupdt) AND 
+              date_lastupdt::date > :'CAPTURE_DATE_PREV'::date 
         GROUP BY job_type) tmp );
 
 INSERT INTO field_dist_qaqc (
@@ -19,5 +20,6 @@ INSERT INTO field_dist_qaqc (
     FROM(
         SELECT job_status, COUNT(DISTINCT job_number) as count
         FROM final_devdb
-        WHERE date_lastupdt >= CAST(:PRE_DATE AS VARCHAR)
+        WHERE is_date(date_lastupdt) AND 
+              date_lastupdt::date > :'CAPTURE_DATE_PREV'::date 
         GROUP BY job_status) tmp );

--- a/sql/qaqc/qaqc_field_distribution.sql
+++ b/sql/qaqc/qaqc_field_distribution.sql
@@ -1,10 +1,10 @@
-DROP TABLE IF EXISTS field_dist_qaqc;
-CREATE TABLE IF NOT EXISTS field_dist_qaqc(
+DROP TABLE IF EXISTS qaqc_field_distribution;
+CREATE TABLE IF NOT EXISTS qaqc_field_distribution(
     field_name character varying,
     result character varying
 );
 
-INSERT INTO field_dist_qaqc (
+INSERT INTO qaqc_field_distribution (
     SELECT 'Job_Type' as field_name,
             jsonb_agg(json_build_object('job_type',tmp.job_type,'count',tmp.count)) as result
     FROM(
@@ -14,7 +14,7 @@ INSERT INTO field_dist_qaqc (
               date_lastupdt::date > :'CAPTURE_DATE_PREV'::date 
         GROUP BY job_type) tmp );
 
-INSERT INTO field_dist_qaqc (
+INSERT INTO qaqc_field_distribution(
     SELECT 'Job_Status' as field_name,
             jsonb_agg(json_build_object('job_status',tmp.job_status,'count',tmp.count)) as result 
     FROM(

--- a/sql/qaqc/qaqc_field_distribution.sql
+++ b/sql/qaqc/qaqc_field_distribution.sql
@@ -10,7 +10,7 @@ INSERT INTO field_dist_qaqc (
     FROM(
         SELECT job_type, COUNT(DISTINCT job_number) as count
         FROM final_devdb
-        WHERE date_filed >= CAST(:PRE_DATE AS VARCHAR)
+        WHERE date_lastupdt >= CAST(:PRE_DATE AS VARCHAR)
         GROUP BY job_type) tmp );
 
 INSERT INTO field_dist_qaqc (
@@ -19,5 +19,5 @@ INSERT INTO field_dist_qaqc (
     FROM(
         SELECT job_status, COUNT(DISTINCT job_number) as count
         FROM final_devdb
-        WHERE date_filed >= CAST(:PRE_DATE AS VARCHAR)
+        WHERE date_lastupdt >= CAST(:PRE_DATE AS VARCHAR)
         GROUP BY job_status) tmp );

--- a/sql/qaqc/qaqc_field_distribution.sql
+++ b/sql/qaqc/qaqc_field_distribution.sql
@@ -1,0 +1,23 @@
+DROP TABLE IF EXISTS field_dist_qaqc;
+CREATE TABLE IF NOT EXISTS field_dist_qaqc(
+    field_name character varying,
+    result character varying
+);
+
+INSERT INTO field_dist_qaqc (
+    SELECT 'Job_Type' as field_name,
+            jsonb_agg(json_build_object('job_type',tmp.job_type,'count',tmp.count)) as result
+    FROM(
+        SELECT job_type, COUNT(DISTINCT job_number) as count
+        FROM final_devdb
+        WHERE date_filed >= CAST(:PRE_DATE AS VARCHAR)
+        GROUP BY job_type) tmp );
+
+INSERT INTO field_dist_qaqc (
+    SELECT 'Job_Status' as field_name,
+            jsonb_agg(json_build_object('job_status',tmp.job_status,'count',tmp.count)) as result 
+    FROM(
+        SELECT job_status, COUNT(DISTINCT job_number) as count
+        FROM final_devdb
+        WHERE date_filed >= CAST(:PRE_DATE AS VARCHAR)
+        GROUP BY job_status) tmp );


### PR DESCRIPTION
As we want to capture the # of new records of each possible type created since the previous version, I am thinking of using date_filed to measure the change. But I am not sure whether we should also look at date permitted or other date-related fields for this change. Also, I fetch all job status/job type info from the final_devdb table. I'd like to hear what others think about this issue. 
