### PR TITLE
QAQC Manual Corrections Addition

### DIFF
--- a/sql/qaqc/qaqc_app.sql
+++ b/sql/qaqc/qaqc_app.sql
@@ -29,7 +29,9 @@ SELECT
     HPD_review.invalid_date_statusx,
     HPD_review.incomp_tract_home,
     HPD_review.dem_nb_overlap,
-    qaqc_app_additions.classa_net_mismatch
+    qaqc_app_additions.classa_net_mismatch,
+    qaqc_app_additions.manual_hny_match_check,
+    qaqc_app_additions.manual_corrections_not_applied
 INTO qaqc_app
 FROM
     FINAL_qaqc HPD_review
@@ -64,4 +66,4 @@ WHERE
     OR HPD_review.units_co_prop_mismatch IS NOT NULL
     OR qaqc_app_additions.classa_net_mismatch = 1
     OR qaqc_app_additions.manual_hny_match_check = 1
-    OR qaqc_app_additions.corrections_not_applied = 1;
+    OR qaqc_app_additions.manual_corrections_not_applied = 1;

--- a/sql/qaqc/qaqc_app.sql
+++ b/sql/qaqc/qaqc_app.sql
@@ -62,4 +62,6 @@ WHERE
     OR HPD_review.dup_bbl_address_units IS NOT NULL
     OR HPD_review.dup_bbl_address IS NOT NULL
     OR HPD_review.units_co_prop_mismatch IS NOT NULL
-    OR qaqc_app_additions.classa_net_mismatch = 1;
+    OR qaqc_app_additions.classa_net_mismatch = 1
+    OR qaqc_app_additions.manual_hny_match_check = 1
+    OR qaqc_app_additions.corrections_not_applied = 1;

--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -27,8 +27,7 @@ hny_id IN (SELECT hny_id FROM hny_no_match)
 )
 UPDATE qaqc_app_additions 
 SET manual_hny_match_check = 1
-FROM qaqc_app_additions q, manual_hny_match_check m
-WHERE q.job_number = m.job_number;
-
+FROM manual_hny_match_check m
+WHERE qaqc_app_additions.job_number = m.job_number;
 UPDATE qaqc_app_additions
 SET manual_hny_match_check=(CASE WHEN manual_hny_match_check=1 THEN 1 ELSE 0 END);

--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -15,3 +15,20 @@ SELECT a.job_number,
 	END) as classa_net_mismatch
 INTO qaqc_app_additions
 FROM FINAL_devdb a;
+
+ALTER TABLE qaqc_app_additions ADD manual_hny_match_check INT;
+WITH manual_hny_match_check AS (SELECT 
+job_number
+FROM corr_hny_matches 
+WHERE 
+action = 'add' 
+AND
+hny_id IN (SELECT hny_id FROM hny_no_match)
+)
+UPDATE qaqc_app_additions 
+SET manual_hny_match_check = 1
+FROM qaqc_app_additions q, manual_hny_match_check m
+WHERE q.job_number = m.job_number;
+
+UPDATE qaqc_app_additions
+SET manual_hny_match_check=(CASE WHEN manual_hny_match_check=1 THEN 1 ELSE 0 END);

--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -17,7 +17,7 @@ INTO qaqc_app_additions
 FROM FINAL_devdb a;
 
 ALTER TABLE qaqc_app_additions ADD manual_hny_match_check INT;
-WITH manual_hny_match_check AS (
+WITH manual_hny_match AS (
     SELECT 
     job_number
     FROM corr_hny_matches 
@@ -29,7 +29,7 @@ WITH manual_hny_match_check AS (
 UPDATE qaqc_app_additions 
 SET manual_hny_match_check = (
     CASE 
-        WHEN qaqc_app_additions.job_number NOT IN (SELECT job_number FROM manual_hny_match_check) THEN 0 
+        WHEN qaqc_app_additions.job_number NOT IN (SELECT job_number FROM manual_hny_match) THEN 0 
         ELSE 1 
     END);
 


### PR DESCRIPTION
#532 one reviewer is good 🐉 

I feel like I lost some steam half way through this because I realize the tables the pipelines generated for manual corrections qaqc are really good! (`corrections_applied` and `corrections_not_applied`). Also keeping in mind that anything we want to add to the app is really to benefit our team members, so I really can only come up with justifications for the two checks added below. 

## maunal_hny_match_check
this is to see if our pipeline added manual corrections from `CORR_hny_matches` adding to a job number was successful. It is pretty simple but should raise a flag because that can indicate the step to incorporate manual corrections for hny, which is distinct from the other manual corrections ingestions, might have failed somehow. 

## manual_corrections_not_applied
pull in this table maybe just to have a total count in our app to make sure this number is somewhat stable. Again the actual job numbers are probably still only useful to the subject matter experts. 

One last overall comment/question is I am hoping the place I added in the query makes some sense in the overall qaqc file creation process. 