### PR TITLE
Check CO 

### DIFF
--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -40,7 +40,12 @@ SET manual_corrections_not_applied=(
         WHEN qaqc_app_additions.job_number IN (SELECT job_number FROM corrections_not_applied) THEN 1 ELSE 0 
     END);
 
-ALTER TABLE qaqc_app_additions ADD complete_year_null INT;
+/*
+If the projects are residential complete or partially complete status
+but the complete_year and complete_quarter are still null. Then it is likely the COs 
+are missing.
+*/
+ALTER TABLE qaqc_app_additions ADD complete_year_quarter_null INT;
 UPDATE qaqc_app_additions
 SET complete_year_quarter_null = (
     CASE 
@@ -49,6 +54,7 @@ SET complete_year_quarter_null = (
             FROM FINAL_devdb 
             WHERE job_status IN ('4. Partially Completed Construction', '5. Completed Construction') 
             AND (complete_year IS NULL OR complete_qrtr IS NULL)
+            AND resid_flag = 'Residential'
         ) THEN 1 ELSE 0
     END
 );

--- a/sql/qaqc/qaqc_app_additions.sql
+++ b/sql/qaqc/qaqc_app_additions.sql
@@ -39,3 +39,16 @@ SET manual_corrections_not_applied=(
     CASE 
         WHEN qaqc_app_additions.job_number IN (SELECT job_number FROM corrections_not_applied) THEN 1 ELSE 0 
     END);
+
+ALTER TABLE qaqc_app_additions ADD complete_year_null INT;
+UPDATE qaqc_app_additions
+SET complete_year_quarter_null = (
+    CASE 
+        WHEN qaqc_app_additions.job_number IN (
+            SELECT job_number 
+            FROM FINAL_devdb 
+            WHERE job_status IN ('4. Partially Completed Construction', '5. Completed Construction') 
+            AND (complete_year IS NULL OR complete_qrtr IS NULL)
+        ) THEN 1 ELSE 0
+    END
+);


### PR DESCRIPTION
#547 🌻 

## Overview
This stems from an issue the housing team spotted during manual research for some records with complete or partial complete status and units completed that their complete date are still missing. This check would indicate something is off with the COs. 

Should be pretty simple work and one reviewer is fine. 