### PR TITLE
Set `job_inactive` to `Inactive: Stalled` only if all date fields show >3 years without a change

### DIFF
--- a/sql/_status.sql
+++ b/sql/_status.sql
@@ -67,6 +67,9 @@ DRAFT_STATUS_devdb as (
         END as job_status,
         a.date_permittd,
         a.date_lastupdt::date,
+        GREATEST(date_lastupdt::date, date_filed::date, date_statusd::date, 
+                 date_statusp::date, date_statusr::date, 
+                 date_statusx::date, date_complete::date ) as _date_lastdupdt, 
         a.classa_init,
         a.classa_prop,
         a.classa_net,
@@ -100,7 +103,7 @@ SELECT
         WHEN date_complete IS NOT NULL 
             THEN NULL
         -- Jobs not (partially) complete that haven't been updated in 3 years
-        WHEN (:'CAPTURE_DATE'::date - date_lastupdt)/365 >= 3 
+        WHEN (:'CAPTURE_DATE'::date - _date_lastupdt)/365 >= 3 
             AND job_status IN ('1. Filed Application', 
                                 '2. Approved Application', 
                                 '3. Permitted for Construction')

--- a/sql/_status.sql
+++ b/sql/_status.sql
@@ -69,7 +69,7 @@ DRAFT_STATUS_devdb as (
         a.date_lastupdt::date,
         GREATEST(date_lastupdt::date, date_filed::date, date_statusd::date, 
                  date_statusp::date, date_statusr::date, 
-                 date_statusx::date, date_complete::date ) as _date_lastdupdt, 
+                 date_statusx::date, date_complete::date, date_permittd ) as _date_lastupdt, 
         a.classa_init,
         a.classa_prop,
         a.classa_net,


### PR DESCRIPTION
Small PR, one reviewer 📆 
Addresses issues #546. We don't want to change the `date_lastupdt` field but we also know it's wrong sometimes. We've addressed this in the past with manual corrections that change `job_inactive` from `Stalled: Inactive` to `NULL`. 
This is a programmatic solution that constructs a new temporary date last updated field (`_date_lastupdt`) in the `DRAFT_STATUS_devdb` common table expression. This new field is used only once to set `job_inactive`. 

I have have missed a usable date field when constructing `_date_lastupdt` so I would have appreciate a careful check that I didn't leave anything out. 

This code makes the 6 manual correction that change `job_inaction` from `Inactive: Stalled` to `NULL` obsolete 