### PR TITLE
change the filter for dob now permits to none

### DIFF
--- a/data/manual_corrections.csv
+++ b/data/manual_corrections.csv
@@ -33272,3 +33272,13 @@ X00670832,classa_prop,1,0,,8/24/22,SL
 123906915,classa_prop,9,12,,8/24/22,SL
 123906915,hotel_prop,9,0,,8/24/22,SL
 123906915,classb_prop,9,0,,8/24/22,SL
+M00484025,classa_init,0,245,,9/7/22,SL
+M00484025,hotel_init,0,0,,9/7/22,SL
+M00484025,hotel_prop,245,0,,9/7/22,SL
+M00484025,classb_init,0,0,,9/7/22,SL
+M00484025,classb_prop,245,0,,9/7/22,SL
+M00483952,classa_init,0,245,,9/7/22,SL
+M00483952,hotel_init,0,0,,9/7/22,SL
+M00483952,hotel_prop,245,0,,9/7/22,SL
+M00483952,classb_init,0,0,,9/7/22,SL
+M00483952,classb_prop,245,0,,9/7/22,SL

--- a/sql/_status_q.sql
+++ b/sql/_status_q.sql
@@ -36,7 +36,6 @@ STATUS_Q_create as (
         left(job_filing_number, strpos(job_filing_number, '-') - 1)::text as job_number,
         min(issued_date::date) as date_permittd 
     FROM dob_now_permits
-    WHERE right(job_filing_number,2)='I1'
     GROUP BY left(job_filing_number, strpos(job_filing_number, '-') - 1)::text
 ) 
 SELECT 

--- a/sql/_status_q.sql
+++ b/sql/_status_q.sql
@@ -41,9 +41,7 @@ STATUS_Q_create as (
 SELECT 
     job_number,
     date_permittd,
-    -- year_permit
     extract(year from date_permittd)::text as permit_year,
-    -- quarter_permit
     year_quarter(date_permittd) as permit_qrtr
 INTO STATUS_Q_devdb
 FROM STATUS_Q_create


### PR DESCRIPTION
#566 for more details 

the change is straightforward in the `sql/_status_q.sql` where the dob_now_permits records are no longer filtered down to the `I1` but to include all types and then taking the `date_permitted` from the earliest record. 

## Review
I use the two examples housing cited as evidence for no correctly assigned permits `M00522293` and `M00558120` and located them in the `final_devdb` to confirm whether their status and `date_permitted` correctly reflect the permits. One thing to pay attention to is this again is pointing to the `main` branch since we want to keep the production consistent since last time. Manual corrections table is updated again because housing has found a few things to correct in the interim. 





