### PR TITLE
Add `cdtaname2020` to intermediate devdb tables and outputs

### DIFF
--- a/sql/_export.sql
+++ b/sql/_export.sql
@@ -114,6 +114,7 @@ SELECT
 	NTA2020 as "NTA2020",
 	NTAName2020 as "NTAName20",
 	CDTA2020 as "CDTA2020",
+	CDTAName2020 as "CDTAName20",
 	ComunityDist as "CommntyDst",
 	CouncilDist as "CouncilDst",
 	SchoolSubDist as "SchSubDist",

--- a/sql/_geo.sql
+++ b/sql/_geo.sql
@@ -105,6 +105,7 @@ DRAFT as (
         b.geo_cb2020, 
         b.geo_ct2020,
         b.geo_cdta2020,
+        b.geo_cdtaname2020,
         b.geo_csd,
         b.geo_policeprct,
         b.geo_firedivision,

--- a/sql/_geo.sql
+++ b/sql/_geo.sql
@@ -105,7 +105,6 @@ DRAFT as (
         b.geo_cb2020, 
         b.geo_ct2020,
         b.geo_cdta2020,
-        b.geo_cdtaname2020,
         b.geo_csd,
         b.geo_policeprct,
         b.geo_firedivision,

--- a/sql/_mid.sql
+++ b/sql/_mid.sql
@@ -136,6 +136,7 @@ SELECT
     a.bctcb2020,
     a.bct2020,
     a.geo_cdta2020,
+    a.geo_cdtaname2020,
     a.geo_csd,
     a.geo_policeprct,
     a.geo_firedivision,

--- a/sql/_spatial.sql
+++ b/sql/_spatial.sql
@@ -200,6 +200,7 @@ SELECT
     dcp_ct2020.nta2020 as geo_nta2020,
     dcp_ct2020.ntaname as geo_ntaname2020,
     dcp_ct2020.cdta2020 as geo_cdta2020,
+    dcp_ct2020.cdtaname as geo_cdtaname2020,
     (SELECT councildst FROM lookup_geo WHERE CENSUS_TRACT_BLOCK.bct2010 = bct2010 LIMIT 1) as geo_council,
     (SELECT commntydst FROM lookup_geo WHERE CENSUS_TRACT_BLOCK.bct2010 = bct2010 LIMIT 1) as geo_cd
 INTO SPATIAL_devdb

--- a/sql/final.sql
+++ b/sql/final.sql
@@ -98,6 +98,7 @@ SELECT
 	MID_devdb.geo_nta2020 as nta2020,
 	MID_devdb.geo_ntaname2020 as ntaname2020,
 	MID_devdb.geo_cdta2020 as cdta2020,
+	MID_devdb.geo_cdtaname2020 as cdtaname2020,
 	MID_devdb.geo_cd as comunitydist,
 	MID_devdb.geo_council as councildist,
 	MID_devdb.geo_schoolsubdist as schoolsubdist,

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -87,6 +87,7 @@ SELECT
     a.bctcb2020,
     a.bct2020,
     a.geo_cdta2020,
+    a.geo_cdtaname2020,
     a.geo_csd,
     a.geo_policeprct,
     a.geo_firedivision,

--- a/sql/qaqc_geo.sql
+++ b/sql/qaqc_geo.sql
@@ -31,6 +31,7 @@ SELECT
             geo_cb2020 IS NULL OR
             geo_ct2020 IS NULL OR
             geo_cdta2020 IS NULL OR
+            geo_cdtaname2020 IS NULL OR
             geo_csd IS NULL OR
             geo_policeprct IS NULL OR
             geo_firedivision IS NULL OR


### PR DESCRIPTION
Addresses issue #571.

@croswell81 and @levysamu wanted to add the CDTA Name 2020 column to the final devdb outputs. This PR addresses this and adds the new column to the final output and corresponding intermediate tables. 

To test this new change, I built devdb locally and checked that the column was in the required tables. 