### PR TITLE
Refactor dataloading from `devdb.sh`

### DIFF
--- a/devdb.sh
+++ b/devdb.sh
@@ -4,12 +4,8 @@ source bash/config.sh
 function dataloading { 
     shift;
     MODE="${1:-edm}"
-    CLEAR="${2:-true}"
     echo "mode: $MODE"
     ./bash/01_dataloading.sh $1
-    if [ "${CLEAR}" == "true" ]; then
-        rm -rf .library
-    fi
 }
 
 function build { 
@@ -140,8 +136,12 @@ function aggregate {
     )
 }
 
+function clear {
+    rm -rf .library
+}
+
 case $1 in
-    dataloading | build | qaqc | aggregate | export | archive ) $@ ;;
+    dataloading | build | qaqc | aggregate | export | archive | clear ) $@ ;;
     upload) Upload;;
     geocode) geocode ;;
     import) import $@ ;;


### PR DESCRIPTION
Small PR for consistency 📚 
Currently `./devdb.sh dataloading` and `./bash/01_dataloading.sh` do different things. The distinction doesn't matter in a production build on github actions but it does matter in local development. I accidentally wiped my `.library` which only took a couple minutes to re-create. If we want to automatically clear we should do that from the `01_dataloading.sh` for more consistent behavior. 