### PR TITLE
community districts city council districts assignment

### DIFF
--- a/sql/_function.sql
+++ b/sql/_function.sql
@@ -98,7 +98,7 @@ CREATE OR REPLACE FUNCTION get_council(
     _geom geometry
   ) 
     RETURNS varchar AS $$
-      SELECT  coundist::varchar
+      SELECT lpad(b.coundist::text,2,'0')::varchar
       FROM dcp_councildistricts b
       WHERE ST_Within(_geom, b.wkb_geometry)
       LIMIT 1

--- a/sql/_function.sql
+++ b/sql/_function.sql
@@ -78,6 +78,26 @@ CREATE OR REPLACE FUNCTION get_csd(
     _geom geometry
   ) 
     RETURNS varchar AS $$
+      SELECT lpad(b.schooldist::text,2,'0')::varchar
+      FROM dcp_school_districts b
+      WHERE ST_Within(_geom, b.wkb_geometry)
+      LIMIT 1
+  $$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION get_cd(
+    _geom geometry
+  ) 
+    RETURNS varchar AS $$
+      SELECT  borocd::varchar
+      FROM dcp_cdboundaries b
+      WHERE ST_Within(_geom, b.wkb_geometry)
+      LIMIT 1
+  $$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION get_council(
+    _geom geometry
+  ) 
+    RETURNS varchar AS $$
       SELECT  coundist::varchar
       FROM dcp_councildistricts b
       WHERE ST_Within(_geom, b.wkb_geometry)

--- a/sql/_spatial.sql
+++ b/sql/_spatial.sql
@@ -99,6 +99,20 @@ CREATE TABLE DRAFT_spatial AS (
             THEN get_csd(geom)
         ELSE a.geo_csd END) as geo_csd, 
 
+        -- geo_cd
+        (CASE WHEN a.geo_cd IS NULL 
+            OR a.geo_cd = '' 
+            OR a.mode = 'tpad'
+            THEN get_cd(geom)
+        ELSE a.geo_cd END) as geo_cd, 
+        
+        -- geo_council
+        (CASE WHEN a.geo_council IS NULL 
+            OR a.geo_council = '' 
+            OR a.mode = 'tpad'
+            THEN get_council(geom)
+        ELSE a.geo_council END) as geo_csd, 
+
         -- geo_policeprct
         (CASE WHEN a.geo_policeprct IS NULL 
             OR a.geo_policeprct = '' 
@@ -174,6 +188,8 @@ SELECT
     DRAFT_spatial.geo_zipcode,
     DRAFT_spatial.geo_boro,
     DRAFT_spatial.geo_csd,
+    DRAFT_spatial.geo_cd,
+    DRAFT_spatial.geo_council,
     DRAFT_spatial.geo_policeprct,
     DRAFT_spatial.geo_firedivision,
     DRAFT_spatial.geo_firebattalion,
@@ -200,9 +216,7 @@ SELECT
     dcp_ct2020.nta2020 as geo_nta2020,
     dcp_ct2020.ntaname as geo_ntaname2020,
     dcp_ct2020.cdta2020 as geo_cdta2020,
-    dcp_ct2020.cdtaname as geo_cdtaname2020,
-    (SELECT councildst FROM lookup_geo WHERE CENSUS_TRACT_BLOCK.bct2010 = bct2010 LIMIT 1) as geo_council,
-    (SELECT commntydst FROM lookup_geo WHERE CENSUS_TRACT_BLOCK.bct2010 = bct2010 LIMIT 1) as geo_cd
+    dcp_ct2020.cdtaname as geo_cdtaname2020
 INTO SPATIAL_devdb
 FROM DRAFT_spatial
 LEFT JOIN CENSUS_TRACT_BLOCK ON DRAFT_spatial.uid = CENSUS_TRACT_BLOCK.uid

--- a/sql/_spatial.sql
+++ b/sql/_spatial.sql
@@ -105,13 +105,13 @@ CREATE TABLE DRAFT_spatial AS (
             OR a.mode = 'tpad'
             THEN get_cd(geom)
         ELSE a.geo_cd END) as geo_cd, 
-        
+
         -- geo_council
         (CASE WHEN a.geo_council IS NULL 
             OR a.geo_council = '' 
             OR a.mode = 'tpad'
             THEN get_council(geom)
-        ELSE a.geo_council END) as geo_csd, 
+        ELSE a.geo_council END) as geo_council, 
 
         -- geo_policeprct
         (CASE WHEN a.geo_policeprct IS NULL 

--- a/sql/_spatial.sql
+++ b/sql/_spatial.sql
@@ -152,6 +152,7 @@ CREATE TABLE DRAFT_spatial AS (
         geomsource
     FROM GEO_devdb a
 );
+DROP INDEX IF EXISTS DRAFT_spatial_uid_idx;
 CREATE INDEX DRAFT_spatial_uid_idx ON DRAFT_spatial(uid);
 
 DROP TABLE IF EXISTS CENSUS_TRACT_BLOCK CASCADE;
@@ -172,10 +173,15 @@ CREATE TABLE CENSUS_TRACT_BLOCK AS (
     FROM DRAFT_spatial
 );
 
+DROP INDEX IF EXISTS CENSUS_TRACT_BLOCK_uid_idx;
+DROP INDEX IF EXISTS dcp_ct2020_boroct2020_idx;
+DROP INDEX IF EXISTS dcp_ct2010_boroct2010_idx;
+DROP INDEX IF EXISTS lookup_geo_bct2010_idx;
 CREATE INDEX CENSUS_TRACT_BLOCK_uid_idx ON CENSUS_TRACT_BLOCK(uid);
 CREATE INDEX dcp_ct2020_boroct2020_idx ON dcp_ct2020(boroct2020);
 CREATE INDEX dcp_ct2010_boroct2010_idx ON dcp_ct2010(boroct2010);
 CREATE INDEX lookup_geo_bct2010_idx ON lookup_geo(bct2010);
+
 
 DROP TABLE IF EXISTS SPATIAL_devdb;
 SELECT


### PR DESCRIPTION
#587 two reviewers preferred ☔ 🌧️ but one required

## Overview
switch over from the rolling up from the census tract to community districts and council districts to using spatial join to fill the missing geometries after Geosupport didn't provide. Then downstream output needs to be modified accordingly to reflect the changes. 

## _functions.sql
the new `get_cd` and `get_council` are pretty much copying over the other spatial join functions. `get_csd` also got modified because it was pointing incorrectly to the city council geographies. 

## Review Tips
I would recommend running the spatial part of the pipeline to get the new geographies then check if the mismatch between CDs and boro mostly seems resolved (on my end it went from 4000+ records to 382 mismatch). Also just in general checking if the new `comunitydist` and `councildist` values make sense.   