### PR TITLE
Reduce number of jobs getting geocoded

### DIFF
--- a/python/geocode.py
+++ b/python/geocode.py
@@ -86,6 +86,9 @@ if __name__ == "__main__":
     # connect to BUILD_ENGINE
     engine = create_engine(os.environ["BUILD_ENGINE"])
 
+    # select records to be geocoded
+    # NOTE: using the Group ID (gid) value to limit selection to
+    #       the most recent version of duplicate records
     df = pd.read_sql(
         """
         SELECT 

--- a/python/geocode.py
+++ b/python/geocode.py
@@ -72,7 +72,8 @@ def parse_output(geo):
         geo_ct2020=geo.get("2020 Census Tract", None),
         geo_cb2010=geo.get("2010 Census Block", None),
         geo_cb2020=geo.get("2020 Census Block", None),
-        geo_cdta2020=geo.get("2020 Community District Tabulation Area (CDTA)", None),
+        geo_cdta2020=geo.get(
+            "2020 Community District Tabulation Area (CDTA)", None),
         # the return codes and messaged are for diagnostic puposes
         grc=geo.get("Geosupport Return Code (GRC)", ""),
         grc2=geo.get("Geosupport Return Code 2 (GRC 2)", ""),
@@ -103,7 +104,9 @@ if __name__ == "__main__":
                 streetname as street_name, 
                 borough,
                 'bis' as source
-            FROM dob_jobapplications UNION
+            FROM dob_jobapplications 
+            where gid::text = '1'
+            UNION
             SELECT 
                 distinct ogc_fid as uid, 
                 house_no as house_number,


### PR DESCRIPTION
#609 one reviewer required

Hey all I did this work awhile ago but somehow forgot to create PR and ask for it to be reviewed. But since we were talking about building devdb this morning which made me wonder if data sync was able to run successfully recently. It turns out [they weren't](https://github.com/NYCPlanning/db-developments/actions/runs/3819342609/jobs/6496891723). 

This was the issue I spotted few weeks ago since the A2 jobs inclusion making geocoding work so much heavier and the step would fail. I did this temporary patch to reduce the number of total jobs to be geocoded but see #609 writeup on my thoughts on this for the future. [Some testing](https://github.com/NYCPlanning/db-developments/actions/runs/3831028221) suggest that this patch worked. 