### PR TITLE
add dob now data to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/update.md
+++ b/.github/ISSUE_TEMPLATE/update.md
@@ -21,7 +21,7 @@ VERSION=20Q4
 VERSION_PREV=20Q2
 ```
 ### Make sure the following are up-to-date in recipes:
-- [ ] `dcp_mappluto`
+- [ ] `dcp_mappluto_wi`
 - [ ] `dof_shoreline` updated with zoningtaxlots, safe to ignore
 - [ ] `council_members` [check opendate](https://data.cityofnewyork.us/City-Government/Council-Members/uvw5-9znb)
 - [ ] `doitt_buildingfootprints` [check opendata](https://data.cityofnewyork.us/Housing-Development/Building-Footprints/nqwf-w8eh)

--- a/.github/ISSUE_TEMPLATE/update.md
+++ b/.github/ISSUE_TEMPLATE/update.md
@@ -46,3 +46,5 @@ VERSION_PREV=20Q2
 - [ ]  `dob_cofos` -> manually updated, received by email
 - [ ]  `dob_jobapplications` [check actions](https://github.com/NYCPlanning/recipes/actions?query=workflow%3A%22DOB+pull+for+HED%22)
 - [ ]  `dob_permitissuance` [check actions](https://github.com/NYCPlanning/recipes/actions?query=workflow%3A%22DOB+pull+for+HED%22)
+- [ ] `dob_now_applications` -> DOB contacts us via email that the data is ready, the data is downloaded from the DOB FTP using credentials, manually uploaded to DO and ingested via Data Library pipeline
+- [ ] `dob_now_permits` -> DOB contacts us via email that the data is ready, the data is downloaded from the DOB FTP using credentials, manually uploaded to DO and ingested via Data Library pipeline

--- a/bash/01_dataloading.sh
+++ b/bash/01_dataloading.sh
@@ -12,7 +12,7 @@ import_public doe_school_subdistricts &
 import_public doe_eszones &
 import_public doe_mszones &
 import_public hpd_hny_units_by_building &
-import_public dcp_mappluto &
+import_public dcp_mappluto_wi &
 import_public doitt_buildingfootprints &
 import_public doitt_buildingfootprints_historical &
 import_public doitt_zipcodeboundaries &


### PR DESCRIPTION
Addresses issue #615 and issue #617

**Notes:**
- Initially this PR was meant to just adjust the issue template to reflect changes to the issue template but after some review I added a very minor change to change the version of dcp_mappluto that DevDB uses in the dataloading step. This does fundamentally change the source data but updates the dataset to include the correct suffix that is followed for our other datasets. See issue here for more  [explanation](https://github.com/NYCPlanning/db-data-library/issues/316)
- Pretty self explanatory but adding the `dob_now_applications` and `dob_now_permits` data to the issue template because as of the last enhancement these are now used in a DevDB build.
- @damonmcc a little background on the differences between the various dob data. This could be a whole day chat but I think understanding the basics will be enough to start:

1. [Difference between DOB Now and DOB BIS](https://www.nyc.gov/site/buildings/property-or-business-owner/guide-to-bis-dobnow-efiling.page)
2. [Difference between a DOB job and a DOB permit ](https://sitecompli.com/knowledge-center/agencies/dob/construction-jobs-permits/difference-between-a-job-application-and-permit/)