### PR TITLE
Remove Weekly DevDB Build Workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       rebuild:
-        description: "Would you like to rebuild DevDB? (yes/no) If no, set archive or export to yes."
+        description: "Would you like to rebuild DevDB (yes/no)? If no, set archive or export to yes."
         required: false
-        default: "yes"
+        default: "no"
       export:
         description: "Would you like to export the outputs and QAQC to DigitalOcean? (yes/no)"
         required: false
@@ -15,23 +15,17 @@ on:
         description: "Would you like to archive developments and dcp_housing to EDM-DATA? (yes/no)"
         required: false
         default: "no"
-      weekly:
-        description: "Is this for weekly devdb? (yes/no)"
-        required: false
-        default: "no"
+#      weekly:
+#        description: "Is this for weekly devdb? (yes/no)"
+#        required: false
+#        default: "no"
 
   # Weekly Devdb Build for HED Dashboard
-  schedule:
-    - cron: "0 6 * * *"
+#  schedule:
+#    - cron: "0 6 * * *"
 
 jobs:
-  Build:
-    name: Building ...
-    if: >-
-      (
-        github.event_name == 'push' &&
-        ! contains(github.event.head_commit.message, '[skip]')
-      ) || github.event_name != 'push'
+  build:
     runs-on: ubuntu-20.04
     services:
       db:
@@ -64,16 +58,12 @@ jobs:
             echo "::set-output name=rebuild::${{  github.event.inputs.rebuild }}"
             echo "::set-output name=archive::${{  github.event.inputs.archive }}"
             echo "::set-output name=export::${{  github.event.inputs.export }}"
-            echo "::set-output name=weekly::${{  github.event.inputs.weekly }}"
+
           else
             echo "::set-output name=rebuild::yes"
             echo "::set-output name=archive::no"
             echo "::set-output name=export::no"
-            if [[ $GITHUB_EVENT_NAME == 'schedule' ]]; then
-              echo "::set-output name=weekly::yes"
-            else
-              echo "::set-output name=weekly::no"
-            fi
+
           fi
 
       - name: install dependencies ...
@@ -87,16 +77,8 @@ jobs:
           sudo apt install python3-pip
           pip3 install pandas sqlalchemy psycopg2
 
-      - name: 1. dataloading for HED weekly builds
-        if: >-
-          steps.config.outputs.weekly == 'yes' && 
-          steps.config.outputs.rebuild == 'yes'
-        run: ./devdb.sh dataloading weekly
-
       - name: 1. dataloading for EDM builds
-        if: >-
-          steps.config.outputs.rebuild == 'yes' &&
-          steps.config.outputs.weekly == 'no'
+        if: steps.config.outputs.rebuild == 'yes' 
         run: ./devdb.sh dataloading edm && ls -l
 
       - name: Clear cache
@@ -114,31 +96,11 @@ jobs:
           ./devdb.sh qaqc
 
       - name: 4. Export ...
-        if: steps.config.outputs.weekly == 'no'
+        if: steps.config.outputs.export == 'yes'
         run: |
           ./devdb.sh export
           ./devdb.sh upload
 
       - name: 5. Archive ...
-        if: >-
-          steps.config.outputs.archive == 'yes' &&
-          steps.config.outputs.weekly == 'no'
+        if: steps.config.outputs.archive == 'yes' 
         run: ./devdb.sh archive
-
-      - name: Export to EDM_DATA/devdb
-        env:
-          EDM_DATA_BUILD_ENGINE: ${{ secrets.EDM_DATA_BUILD_ENGINE }}
-        if: always() && steps.config.outputs.weekly == 'no'
-        run: |
-          pg_dump $BUILD_ENGINE -O -c | psql $EDM_DATA_BUILD_ENGINE
-
-      - name: Export to HED database
-        if: >-
-          steps.config.outputs.weekly == 'yes' && 
-          steps.config.outputs.rebuild == 'yes'
-        run: |
-          pg_dump -t export_devdb $BUILD_ENGINE -O -c | psql $HED_BUILD_ENGINE &
-          pg_dump -t dcp_mappluto $BUILD_ENGINE -O -c | psql $HED_BUILD_ENGINE &
-          pg_dump -t hpd_hny_units_by_building $BUILD_ENGINE -O -c | psql $HED_BUILD_ENGINE &
-          wait 
-          echo "done!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
           - 25060:5432
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@localhost:25060/devdb
-      HED_BUILD_ENGINE: ${{ secrets.HED_BUILD_ENGINE }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
       AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       rebuild:
         description: "Would you like to rebuild DevDB (yes/no)? If no, set archive or export to yes."
-        required: false
-        default: "no"
+        required: true
+        default: "yes"
       export:
         description: "Would you like to export the outputs and QAQC to DigitalOcean? (yes/no)"
         required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,6 @@ on:
         description: "Would you like to archive developments and dcp_housing to EDM-DATA? (yes/no)"
         required: false
         default: "no"
-#      weekly:
-#        description: "Is this for weekly devdb? (yes/no)"
-#        required: false
-#        default: "no"
-
-  # Weekly Devdb Build for HED Dashboard
-#  schedule:
-#    - cron: "0 6 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
Addresses an issue we identified in #623.

Notes:

- The Github Actions were erroneously exporting data that would overwrite production builds in DO making it impossible to archive and QAQC any of our prior builds. We realized there was an issue because our QAQC app didn't have any data related to the 22Q2 production release of DevDB.
- This PR is meant to get rid of the weekly build of DevDB that was used by Te for (a now deprecated Dashboard he used for QAQC) and any exports related to outputting to the HED Build Engine
- I would like some feedback if we think this is overkill but I think simplifying the "test" workflow as much as possible where the Action has to be triggered directly by the engineer is a better practice than what we had in the past.
- Here is the successful build of [DevDB](https://github.com/NYCPlanning/db-developments/actions/runs/4263872535/jobs/7421168942) using the `test.yml` 

FYI
- We still have the outstanding issue that we don't have a properly archived version of 22Q2 in `edm-publishing/db-developments/main/22Q2` but we do have a published version of the key database files on [Bytes](https://www.nyc.gov/site/planning/data-maps/open-data.page).  The difference in these are that the version available on Bytes are just the key files including a final CSV of Housing and Dev DB along with associated Shapefiles while the files on Digital Ocean have the all important  QAQC csv's and aggregate tables. To get around (a part of) the issue of the overwritten outputs for 22Q2, I manually uploaded a version of 22Q2's `qaqc_historic.sql` which is needed for the QAQC app to compare version of DevDB production builds

Happy to chat about this 

