### PR TITLE
Upgrade postgres version, update names of workflows and update checkout action to V3

### DIFF
--- a/.github/workflows/data_sync.yml
+++ b/.github/workflows/data_sync.yml
@@ -1,4 +1,4 @@
-name: Data Sync
+name: Data Sync and Geocoding of HPD and DOB Data
 on:
   push:
     paths:
@@ -30,7 +30,7 @@ jobs:
           - dob_jobapplications
           - hpd_hny_units_by_building
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: NYCPlanning/action-library-archive@v1.1
         with:
@@ -47,7 +47,7 @@ jobs:
     needs: sync
     services:
       db:
-        image: postgis/postgis:11-3.0-alpine
+        image: postgis/postgis:12-3.0-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -65,7 +65,7 @@ jobs:
       AWS_S3_BUCKET: edm-recipes
       BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Load to Database (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     types:
       - published
   workflow_dispatch:
-  
 
 jobs:
   publish:
@@ -16,7 +15,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: edm-recipes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Version
         id: version
@@ -24,33 +23,33 @@ jobs:
           source version.env
           echo "::set-output name=version::$VERSION"
           echo "Version is $VERSION"
-      
+
       - uses: NYCPlanning/action-library-archive@v1.1
         id: dcp_housing
         with:
-          path: templates/dcp_housing.yml 
+          path: templates/dcp_housing.yml
           s3: true
           latest: true
           compress: true
           output_format: shapefile csv pgdump
           version: ${{ steps.version.outputs.version }}
-      
+
       - uses: NYCPlanning/action-library-archive@v1.1
         id: dcp_developments
         with:
-          path: templates/dcp_developments.yml 
+          path: templates/dcp_developments.yml
           s3: true
           latest: true
           compress: true
           output_format: shapefile csv pgdump
           version: ${{ steps.version.outputs.version }}
-      
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
           service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
           export_default_credentials: true
-      
+
       - name: Archive to BigQuery
         run: ./devdb.sh bq

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       db:
-        image: postgis/postgis:13-3.3-alpine
+        image: postgis/postgis:12-3.0-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: devdb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run a build of DevDB/HousingDB
+name: Run DevDB/HousingDB
 on:
   push:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test - github hosted database
+name: Run a build of DevDB/HousingDB
 on:
   push:
   workflow_dispatch:
@@ -40,7 +40,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: config workflows
         id: config
@@ -69,7 +69,7 @@ jobs:
           pip3 install pandas sqlalchemy psycopg2
 
       - name: 1. dataloading for EDM builds
-        if: steps.config.outputs.rebuild == 'yes' 
+        if: steps.config.outputs.rebuild == 'yes'
         run: ./devdb.sh dataloading edm && ls -l
 
       - name: Clear cache
@@ -93,5 +93,5 @@ jobs:
           ./devdb.sh upload
 
       - name: 5. Archive ...
-        if: steps.config.outputs.archive == 'yes' 
+        if: steps.config.outputs.archive == 'yes'
         run: ./devdb.sh archive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       db:
-        image: postgis/postgis:12-3.0-alpine
+        image: postgis/postgis:13-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: devdb


### PR DESCRIPTION
## motivations

- resolves issue #636
- Update and standardize Github workflow's 
- Create more descriptive names for Github Actions

## changes

- Update and standardize Github workflow's to Postgres 12.3 and update checkout to v3 [documentation](https://github.com/actions/checkout)
- Create more descriptive names for Github Actions

## notes

- Here are the successful (test) [runs](https://github.com/NYCPlanning/db-developments/actions/runs/4734629498/jobs/8403812974)

## todo

- I think it is safe to remove the `corr_checker.yml` file as this workflow hasn't been run recently and we ingest corrections using our standard manual corrections processes. I am happy to remove this for the sake of repo clean up but will wait for comments.
- There's probably some more work that could be done to clean this repo up but I think just updating the Github Actions workflows is a great first step and sticks to our initial plan of maintenance tasks
